### PR TITLE
type checking - first draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "krl-stdlib",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -64,13 +64,13 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -88,13 +88,13 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.0.3"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-union": {
@@ -131,14 +131,38 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -148,9 +172,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "brace-expansion": {
@@ -190,16 +214,34 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "chokidar": {
@@ -208,9 +250,8 @@
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -235,9 +276,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -247,9 +288,9 @@
       "dev": true
     },
     "co-callback": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.0.tgz",
-      "integrity": "sha1-7BtFewjvKCCrMW/8mQZFPgoCde4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.1.tgz",
+      "integrity": "sha512-frKVXlf1KFrlzojOrHIR4HPW6MPu78xb7eYp0xqvSY7ryoJjt5tlxf67ZQq8ABL0jIC7OsB4FShNTzRL0Sk/Vg==",
       "dev": true,
       "requires": {
         "co": "4.6.0"
@@ -283,7 +324,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
     },
@@ -294,13 +335,14 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "debug": {
@@ -331,7 +373,15 @@
       "dev": true,
       "requires": {
         "foreach": "2.0.5",
-        "object-keys": "0.4.0"
+        "object-keys": "1.0.11"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
+        }
       }
     },
     "defined": {
@@ -352,7 +402,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "doctrine": {
@@ -372,13 +422,13 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
+      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
@@ -402,16 +452,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
-      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
+      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.1.0",
         "concat-stream": "1.6.0",
-        "cross-spawn": "4.0.2",
+        "cross-spawn": "5.1.0",
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
@@ -423,11 +473,11 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.1",
+        "inquirer": "3.2.3",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -440,6 +490,7 @@
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -461,7 +512,7 @@
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -526,7 +577,7 @@
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
         "tmp": "0.0.31"
       }
@@ -675,909 +726,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -1651,7 +803,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1670,15 +822,15 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1704,15 +856,15 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
+      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "external-editor": "2.0.4",
         "figures": "2.0.0",
         "lodash": "4.17.4",
@@ -1723,52 +875,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "is-binary-path": {
@@ -1777,7 +883,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -1949,9 +1055,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -2037,7 +1143,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-fn": {
@@ -2082,13 +1188,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-      "dev": true,
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2101,7 +1200,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "object-assign": {
@@ -2154,6 +1253,16 @@
         "tree-kill": "1.1.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2320,9 +1429,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -2342,24 +1451,23 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -2419,9 +1527,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2469,6 +1577,21 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -2510,23 +1633,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "string.prototype.trim": {
@@ -2536,17 +1642,25 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.0",
-        "function-bind": "1.1.0"
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {
@@ -2583,6 +1697,28 @@
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -2629,10 +1765,10 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
         "for-each": "0.3.2",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "glob": "7.1.2",
         "has": "1.0.1",
         "inherits": "2.0.3",
@@ -2644,6 +1780,18 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2697,15 +1845,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
         }
       }
     },
@@ -2752,9 +1891,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -2779,6 +1918,15 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dev": true,
+      "requires": {
+        "object-keys": "0.4.0"
       }
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -64,13 +64,13 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -88,13 +88,13 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.0.3"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-union": {
@@ -131,14 +131,38 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -148,9 +172,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "brace-expansion": {
@@ -190,16 +214,34 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "chokidar": {
@@ -208,7 +250,7 @@
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
         "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
@@ -235,9 +277,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -247,9 +289,9 @@
       "dev": true
     },
     "co-callback": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.0.tgz",
-      "integrity": "sha1-7BtFewjvKCCrMW/8mQZFPgoCde4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.1.tgz",
+      "integrity": "sha512-frKVXlf1KFrlzojOrHIR4HPW6MPu78xb7eYp0xqvSY7ryoJjt5tlxf67ZQq8ABL0jIC7OsB4FShNTzRL0Sk/Vg==",
       "dev": true,
       "requires": {
         "co": "4.6.0"
@@ -283,7 +325,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
     },
@@ -294,13 +336,14 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "debug": {
@@ -331,7 +374,15 @@
       "dev": true,
       "requires": {
         "foreach": "2.0.5",
-        "object-keys": "0.4.0"
+        "object-keys": "1.0.11"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
+        }
       }
     },
     "defined": {
@@ -372,13 +423,13 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
+      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
@@ -402,16 +453,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
-      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
+      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.1.0",
         "concat-stream": "1.6.0",
-        "cross-spawn": "4.0.2",
+        "cross-spawn": "5.1.0",
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
@@ -423,9 +474,9 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.1",
+        "inquirer": "3.2.3",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.9.1",
         "json-stable-stringify": "1.0.1",
@@ -440,6 +491,7 @@
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -461,7 +513,7 @@
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -682,7 +734,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
+        "nan": "2.7.0",
         "node-pre-gyp": "0.6.36"
       },
       "dependencies": {
@@ -1444,14 +1496,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1460,6 +1504,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -1575,9 +1627,9 @@
       }
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -1651,7 +1703,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1676,9 +1728,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1704,15 +1756,15 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
+      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "external-editor": "2.0.4",
         "figures": "2.0.0",
         "lodash": "4.17.4",
@@ -1723,52 +1775,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "is-binary-path": {
@@ -1777,7 +1783,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -2037,7 +2043,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-fn": {
@@ -2083,9 +2089,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
       "dev": true,
       "optional": true
     },
@@ -2101,7 +2107,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "object-assign": {
@@ -2154,6 +2160,16 @@
         "tree-kill": "1.1.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2320,9 +2336,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -2342,24 +2358,23 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -2469,6 +2484,21 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -2493,15 +2523,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2510,23 +2531,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "string.prototype.trim": {
@@ -2536,17 +2540,34 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.0",
-        "function-bind": "1.1.0"
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {
@@ -2583,6 +2604,28 @@
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -2629,10 +2672,10 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
         "for-each": "0.3.2",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "glob": "7.1.2",
         "has": "1.0.1",
         "inherits": "2.0.3",
@@ -2644,6 +2687,18 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2697,15 +2752,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
         }
       }
     },
@@ -2752,9 +2798,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -2779,6 +2825,15 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dev": true,
+      "requires": {
+        "object-keys": "0.4.0"
       }
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "krl-stdlib",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -14,6 +15,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -24,10 +28,16 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -57,19 +67,29 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -81,7 +101,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -111,7 +134,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -129,19 +157,31 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -153,25 +193,46 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chokidar": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -189,6 +250,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.0.tgz",
       "integrity": "sha1-7BtFewjvKCCrMW/8mQZFPgoCde4=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "concat-map": {
@@ -201,7 +280,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.2",
+        "typedarray": "0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -213,13 +297,20 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.2.14"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deep-equal": {
       "version": "0.1.2",
@@ -238,13 +329,9 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
-      "dependencies": {
-        "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-          "dev": true
-        }
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "0.4.0"
       }
     },
     "defined": {
@@ -257,13 +344,26 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -272,16 +372,28 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -290,40 +402,93 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.1.1.tgz",
-      "integrity": "sha1-+svfz+Pg+s06i4DcmMTmwTrlgt8=",
-      "dev": true
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.2",
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "4.0.2",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.0",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.2.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.9.1",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "4.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.1",
+        "text-table": "0.2.0"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -341,24 +506,44 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "external-editor": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.31"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -372,6 +557,15 @@
       "resolved": "https://registry.npmjs.org/faucet/-/faucet-0.0.1.tgz",
       "integrity": "sha1-WX3PHSGJosBiMhtZHo8VHtIDnZw=",
       "dev": true,
+      "requires": {
+        "defined": "0.0.0",
+        "duplexer": "0.1.1",
+        "minimist": "0.0.5",
+        "sprintf": "0.1.5",
+        "tap-parser": "0.4.3",
+        "tape": "2.3.3",
+        "through2": "0.2.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.5",
@@ -383,7 +577,15 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
           "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "deep-equal": "0.1.2",
+            "defined": "0.0.0",
+            "inherits": "2.0.3",
+            "jsonify": "0.0.0",
+            "resumer": "0.0.0",
+            "through": "2.3.8"
+          }
         }
       }
     },
@@ -391,13 +593,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -409,19 +618,35 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -433,7 +658,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -453,6 +681,10 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -464,7 +696,11 @@
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -481,7 +717,11 @@
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -522,22 +762,35 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -564,7 +817,10 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -585,13 +841,19 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -605,7 +867,10 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -628,7 +893,10 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -651,7 +919,12 @@
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -661,25 +934,49 @@
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -692,7 +989,15 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -709,7 +1014,11 @@
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -721,7 +1030,13 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -732,12 +1047,21 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -753,7 +1077,10 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -776,7 +1103,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -794,7 +1124,10 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -813,6 +1146,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -830,12 +1169,18 @@
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -845,7 +1190,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -857,19 +1205,40 @@
           "version": "0.6.36",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -891,7 +1260,10 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -909,7 +1281,11 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -944,6 +1320,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -956,18 +1338,54 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -996,13 +1414,27 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1015,12 +1447,20 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1031,7 +1471,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1042,25 +1485,46 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -1089,13 +1553,19 @@
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -1110,35 +1580,44 @@
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1150,7 +1629,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -1162,12 +1649,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
     "iconv-lite": {
@@ -1192,7 +1691,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1201,16 +1704,81 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.1.1.tgz",
-      "integrity": "sha512-H50sHQwgvvaTBd3HpKMVtL/u6LoHDvYym51gd7bGQe/+9HkCE+J0/3N5FJLfd6O6oz44hHewC2Pc2LodzWVafQ==",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.1.0",
+        "external-editor": "2.0.4",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -1240,7 +1808,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -1270,19 +1841,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1294,13 +1865,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -1320,23 +1897,23 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -1360,31 +1937,47 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "jschardet": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
-      "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -1392,23 +1985,24 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -1419,13 +2013,32 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -1437,7 +2050,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -1449,7 +2065,10 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -1480,7 +2099,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1489,9 +2111,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.2.2.tgz",
-      "integrity": "sha1-yCEV5PzIiK6hTWTCLk8X9qcNXlo=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
       "dev": true
     },
     "object-keys": {
@@ -1504,19 +2126,33 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onchange": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/onchange/-/onchange-3.2.1.tgz",
       "integrity": "sha1-dmkxLIqPlNgLRZXcir5dEZVZ9+A=",
       "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chokidar": "1.6.1",
+        "cross-spawn": "4.0.2",
+        "minimist": "1.2.0",
+        "tree-kill": "1.1.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1530,13 +2166,24 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -1548,7 +2195,13 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1584,7 +2237,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "4.0.0",
@@ -1627,18 +2283,28 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
@@ -1646,7 +2312,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -1654,19 +2323,38 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
       "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.2",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -1690,13 +2378,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1708,25 +2403,38 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -1738,12 +2446,21 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "set-immediate-shim": {
@@ -1780,13 +2497,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -1798,7 +2522,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -1806,13 +2533,21 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1830,13 +2565,37 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
       "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
+      }
     },
     "tap-parser": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.4.3.tgz",
       "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1848,7 +2607,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1859,23 +2624,26 @@
       }
     },
     "tape": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.7.0.tgz",
-      "integrity": "sha512-ePzu2KfZYVtq0v+KKGxBJ9HJWYZ4MaQWeGabD+KpVdMKRen3NJPf6EiwA5BxfMkhQPGtCwnOFWelcB39bhOUng==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
+      "requires": {
+        "deep-equal": "0.1.2",
+        "defined": "0.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
       "dependencies": {
-        "deep-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-          "dev": true
-        },
-        "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -1901,6 +2669,10 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1912,7 +2684,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1924,7 +2702,10 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-keys": "0.4.0"
+          }
         }
       }
     },
@@ -1932,7 +2713,10 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "tree-kill": {
       "version": "1.1.0",
@@ -1950,7 +2734,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -1968,7 +2755,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -1986,13 +2776,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "onchange -i src/ -- npm test",
     "lint": "eslint src/ && echo lint-ok",
-    "xtest": "node src/tests.js | faucet",
     "test": "npm run lint -s && node src/tests.js | faucet"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "onchange -i src/ -- npm test",
     "lint": "eslint src/ && echo lint-ok",
+    "xtest": "node src/tests.js | faucet",
     "test": "npm run lint -s && node src/tests.js | faucet"
   },
   "repository": {
@@ -24,8 +25,8 @@
   },
   "homepage": "https://github.com/Picolab/node-krl-stdlib#readme",
   "devDependencies": {
-    "co-callback": "^1.2.0",
-    "eslint": "^4.4.1",
+    "co-callback": "^1.2.1",
+    "eslint": "^4.6.1",
     "faucet": "^0.0.1",
     "onchange": "^3.2.1",
     "tape": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krl-stdlib",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Standard library for KRL",
   "main": "src/index.js",
   "scripts": {
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/Picolab/node-krl-stdlib#readme",
   "devDependencies": {
     "co-callback": "^1.2.0",
-    "eslint": "^4.1.1",
+    "eslint": "^4.4.1",
     "faucet": "^0.0.1",
     "onchange": "^3.2.1",
-    "tape": "^4.7.0"
+    "tape": "^4.8.0"
   },
   "dependencies": {
     "lodash": "^4.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krl-stdlib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Standard library for KRL",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krl-stdlib",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Standard library for KRL",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,9 @@ stdlib.extract = function(ctx, val, regex){
         return [];
     }
     val = types.toString(val);
-    regex = types.cleanNulls(regex);
+    if(!types.isRegExp(regex)){
+        regex = new RegExp(types.toString(regex));
+    }
     var r = val.match(regex);
     if(!r){
         return [];

--- a/src/index.js
+++ b/src/index.js
@@ -504,6 +504,7 @@ stdlib.join = function(ctx, val, str){
     if(!types.isArray(val)){
         return val;
     }
+    val = types.cleanNulls(val);
     if(arguments.length < 3){
         return _.join(val, ",");
     }
@@ -862,6 +863,7 @@ stdlib.once = function(ctx, val){
         return val;
     }
     //TODO optimize
+    val = types.cleanNulls(val);
     var r = [];
     _.each(_.groupBy(val), function(group){
         if(group.length === 1){
@@ -875,6 +877,7 @@ stdlib.duplicates = function(ctx, val){
         return [];
     }
     //TODO optimize
+    val = types.cleanNulls(val);
     var r = [];
     _.each(_.groupBy(val), function(group){
         if(group.length > 1){

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ var iterBase = function*(val, iter){
 
 // some guidelines/suggestions:
 // 0. effectively check arguments.length when not fixed by the grammar (and consider null versus omitted)
-// 1. convert NaN's/void 0's to nulls (if cleanNulls could possibly have an effect) for all return values and other relevant values
+// 1. convert NaN's/void 0's when needed (i.e. use cleanNulls)
 // 2. don't mutate deep (array/map) arguments (cleanNulls doesn't, assignment can't)
 // 3. where strings/numbers/arrays are expected, convert to them when reasonable (don't coerce arrays to maps)
 // 4. prioritize errors on val's type (if applicable), then argument values/types/0. from left to right
@@ -83,7 +83,7 @@ stdlib["!="] = function(ctx, left, right){
 
 stdlib["+"] = function(ctx, left, right){
     if(arguments.length < 3){
-        return types.cleanNulls(left);
+        return left;
     }
     //if we have two "numbers" then do plus
     if(types.isNumber(left) && types.isNumber(right)){
@@ -98,7 +98,7 @@ stdlib["-"] = function(ctx, left, right){
         if(leftNumber === null){
             throw new TypeError("Cannot negate " + types.toString(left));
         }
-        return -types.cleanNulls(leftNumber);
+        return -leftNumber;
     }
     var rightNumber = types.numericCast(right);
     if(leftNumber === null || rightNumber === null){
@@ -184,7 +184,7 @@ stdlib.beesting = function(ctx, val){
 //
 stdlib.as = function(ctx, val, type){
     if(arguments.length < 3){
-        return types.cleanNulls(val);
+        return val;
     }
     var val_type = types.typeOf(val);
     if(val_type === type){
@@ -228,11 +228,10 @@ stdlib.isnull = function(ctx, val){
 };
 
 stdlib.klog = function(ctx, val, message){
-    val = types.cleanNulls(val);
     if(arguments.length < 3){
         ctx.emit("klog", {val: val});
     }else{
-        ctx.emit("klog", {val: val, message: types.cleanNulls(message)});
+        ctx.emit("klog", {val: val, message: types.toString(message)});
     }
     return val;
 };
@@ -243,7 +242,7 @@ stdlib["typeof"] = function(ctx, val){
 
 var format = function(val, template, specifier){
     return _.join(
-        _.map(types.toString(template).split(/\\\\/g), function(v){
+        _.map(template.split(/\\\\/g), function(v){
             return v.replace(new RegExp("(^|[^\\\\])" + specifier, "g"), "$1" + val + "");
         }),
         "\\"
@@ -254,7 +253,7 @@ stdlib.sprintf = function(ctx, val, template){
     if(arguments.length < 3){
         return "";
     }
-    template = types.cleanNulls(template);
+    template = types.toString(template);
     if(types.isNumber(val)){
         return format(val, template, "%d");
     }
@@ -266,12 +265,14 @@ stdlib.sprintf = function(ctx, val, template){
 
 stdlib.defaultsTo = function(ctx, val, defaultVal, message){
     if(!types.isNull(val)){
-        return types.cleanNulls(val); // not important whether defaultVal is missing
+        return val; // not important whether defaultVal is missing
     }
     if(arguments.length < 3){
         throw new Error("The .defaultsTo() operator needs a default value");
     }
-    if(!types.isNull(message)) ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
+    if(!types.isNull(message)){
+        ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
+    }
     return types.cleanNulls(defaultVal);
 };
 
@@ -305,7 +306,7 @@ stdlib.capitalize = function(ctx, val){
 };
 stdlib.decode = function(ctx, val){
     if(!types.isString(val)){
-        return types.cleanNulls(val);
+        return val;
     }
     try{
         return JSON.parse(val);
@@ -347,7 +348,7 @@ stdlib.ord = function(ctx, val){
 };
 stdlib.replace = function(ctx, val, regex, replacement){
     if(arguments.length < 3){
-        return types.cleanNulls(val);
+        return val;
     }
     val = types.toString(val);
     if(!types.isString(regex) && !types.isRegExp(regex)){
@@ -360,13 +361,15 @@ stdlib.replace = function(ctx, val, regex, replacement){
 };
 stdlib.split = function(ctx, val, split_on){
     val = types.toString(val);
-    split_on = types.cleanNulls(split_on); // toString?
+    if( ! types.isRegExp(split_on)){
+        split_on = types.toString(split_on);
+    }
     return val.split(split_on);
 };
 stdlib.substr = function(ctx, val, start, len){
     start = types.numericCast(start);
     if(start === null){
-        return types.cleanNulls(val);
+        return val;
     }
     val = types.toString(val);
     if(start > val.length){
@@ -391,7 +394,6 @@ stdlib.uc = function(ctx, val){
 //Collection operators//////////////////////////////////////////////////////////
 //operators using KRL functions are generators to be async-friendly (co library)
 stdlib.all = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         val = [val];
     }
@@ -416,7 +418,6 @@ stdlib.any = function*(ctx, val, iter){
     if(!types.isFunction(iter)){
         return false;
     }
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         val = [val];
     }
@@ -435,14 +436,13 @@ stdlib.none = function*(ctx, val, iter){
     return !(yield stdlib.any(ctx, val, iter));
 };
 stdlib.append = function(ctx, val, others){
-    return _.concat.apply(void 0, types.cleanNulls(_.tail(_.toArray(arguments))));
+    return _.concat.apply(void 0, _.tail(_.toArray(arguments)));
 };
 // works for arrays (documented) and maps (undocumented)
 stdlib.collect = function*(ctx, val, iter){
     if(!types.isFunction(iter)){
         return {};
     }
-    val = types.cleanNulls(val);
     if(!types.isArrayOrMap(val)){
         val = [val];
     }
@@ -458,7 +458,6 @@ stdlib.collect = function*(ctx, val, iter){
     return grouped;
 };
 stdlib.filter = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isFunction(iter)){
         return val;
     }
@@ -482,15 +481,15 @@ stdlib.filter = function*(ctx, val, iter){
 };
 stdlib.head = function(ctx, val){
     if(!types.isArray(val)){
-        return types.cleanNulls(val); // head is for arrays; pretend val is a one-value array
+        return val; // head is for arrays; pretend val is a one-value array
     }
-    return types.cleanNulls(val[0]);
+    return val[0];
 };
 stdlib.tail = function(ctx, val){
     if(!types.isArray(val)){
         return [];
     }
-    return types.cleanNulls(_.tail(val));
+    return _.tail(val);
 };
 stdlib.index = function(ctx, val, elm){
     if(arguments.length < 3){
@@ -504,7 +503,6 @@ stdlib.index = function(ctx, val, elm){
     return _.findIndex(val, _.partial(_.isEqual, elm));
 };
 stdlib.join = function(ctx, val, str){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
@@ -521,7 +519,6 @@ stdlib.length = function(ctx, val){
     return 0; // we could check function.prototype.length
 };
 stdlib.map = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isFunction(iter)){
         return val;
     }
@@ -570,7 +567,7 @@ stdlib.pairwise = function*(ctx, val, iter){
     for(i = 0; i < max_len; i++){
         args2 = [];
         for(j = 0; j < val.length; j++){
-            args2.push(types.cleanNulls(val[j][i]));
+            args2.push(val[j][i]);
         }
         r.push(yield iter(ctx, args2));
     }
@@ -582,20 +579,19 @@ stdlib.reduce = function*(ctx, val, iter, dflt){
     }
     var no_default = arguments.length < 4;
     if(val.length === 0){
-        return no_default ? 0 : types.cleanNulls(dflt);
+        return no_default ? 0 : dflt;
     }
     if(!types.isFunction(iter) && (no_default || val.length > 1)){
         throw new Error("The .reduce() operator cannot use " + types.toString(iter) + " as a function");
     }
     if(val.length === 1){
-        var head = types.cleanNulls(val[0]);
+        var head = val[0];
         if(no_default){
             return head;
         }
-        return iter(ctx, [types.cleanNulls(dflt), head]);
+        return iter(ctx, [dflt, head]);
     }
-    val = types.cleanNulls(val);
-    var acc = types.cleanNulls(dflt);
+    var acc = dflt;
     var is_first = true;
     yield iterBase(val, function*(v, k, obj){
         if(is_first && no_default){
@@ -609,11 +605,10 @@ stdlib.reduce = function*(ctx, val, iter, dflt){
     return acc;
 };
 stdlib.reverse = function(ctx, val){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
-    return _.reverse(val);
+    return _.reverse(_.cloneDeep(val));
 };
 stdlib.slice = function(ctx, val, start, end){
     if(!types.isArray(val)){
@@ -623,7 +618,7 @@ stdlib.slice = function(ctx, val, start, end){
         return null;
     }
     if(arguments.length === 2){
-        return types.cleanNulls(val);
+        return val;
     }
     var firstIndex = types.numericCast(start);
     if(firstIndex === null){
@@ -634,7 +629,7 @@ stdlib.slice = function(ctx, val, start, end){
             ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from 0 to " + firstIndex));
             return null;
         }
-        return types.cleanNulls(_.slice(val, 0, firstIndex + 1));
+        return _.slice(val, 0, firstIndex + 1);
     }
     var secondIndex = types.numericCast(end);
     if(secondIndex === null){
@@ -646,7 +641,7 @@ stdlib.slice = function(ctx, val, start, end){
         secondIndex = temp;
     }
     if(firstIndex >= 0 && secondIndex < val.length){
-        return types.cleanNulls(_.slice(val, firstIndex, secondIndex + 1));
+        return _.slice(val, firstIndex, secondIndex + 1);
     }
     ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from " + firstIndex + " to " + secondIndex));
     return null;
@@ -677,12 +672,12 @@ stdlib.splice = function(ctx, val, start, n_elms, value){
     if(n_elms_number < 0 || startIndex + n_elms_number > val.length){
         n_elms_number = val.length - startIndex;
     }
-    var part1 = types.cleanNulls(_.slice(val, 0, startIndex));
-    var part2 = types.cleanNulls(_.slice(val, startIndex + n_elms));
+    var part1 = _.slice(val, 0, startIndex);
+    var part2 = _.slice(val, startIndex + n_elms);
     if(arguments.length < 5){
         return _.concat(part1, part2);
     }
-    return _.concat(part1, types.cleanNulls(value), part2);
+    return _.concat(part1, value, part2);
 };
 stdlib.sort = (function(){
     var swap = function(arr, i, j){
@@ -691,7 +686,7 @@ stdlib.sort = (function(){
         arr[j] = temp;
     };
     return function*(ctx, val, sort_by){
-        val = types.cleanNulls(val);
+        val = _.cloneDeep(val);
         if(!types.isArray(val)){
             return val;
         }
@@ -718,6 +713,7 @@ stdlib.sort = (function(){
         var sorted = val;
         var i, j, a, b;
         var len = sorted.length;
+        //TODO optimize with a better sort algorithm
         for (i = len - 1; i >= 0; i--){
             for(j = 1; j <= i; j++){
                 a = sorted[j-1];
@@ -733,7 +729,7 @@ stdlib.sort = (function(){
 stdlib["delete"] = function(ctx, val, path){
     path = toKeyPath(path);
     //TODO optimize
-    var n_val = types.cleanNulls(val);
+    var n_val = _.cloneDeep(val);
     _.unset(n_val, path);
     return n_val;
 };
@@ -747,7 +743,6 @@ var isSafeArrayIndex = function(arr, key){
 };
 
 stdlib.put = function(ctx, val, path, to_set){
-    val = types.cleanNulls(val);
     if(!types.isArrayOrMap(val) || arguments.length < 3){
         return val;
     }
@@ -755,6 +750,7 @@ stdlib.put = function(ctx, val, path, to_set){
         to_set = path;
         path = [];
     }
+    val = _.cloneDeep(val);
     path = toKeyPath(path);
     if(_.isEmpty(path)){
         if(types.isMap(to_set)){
@@ -803,7 +799,6 @@ stdlib.keys = function(ctx, val, path){
         return [];
     }
     if(path){
-        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.keys(_.get(val, path));
     }
@@ -814,11 +809,10 @@ stdlib.values = function(ctx, val, path){
         return [];
     }
     if(path){
-        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.values(_.get(val, path));
     }
-    return types.cleanNulls(_.values(val));
+    return _.values(val);
 };
 stdlib.intersection = function(ctx, a, b){
     if(arguments.length < 3){
@@ -872,7 +866,6 @@ stdlib.has = function(ctx, val, other){
     return stdlib.difference(ctx, other, val).length === 0;
 };
 stdlib.once = function(ctx, val){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
@@ -891,7 +884,6 @@ stdlib.duplicates = function(ctx, val){
     }
     //TODO optimize
     var r = [];
-    val = types.cleanNulls(val);
     _.each(_.groupBy(val), function(group){
         if(group.length > 1){
             r.push(group[0]);
@@ -912,7 +904,6 @@ stdlib["get"] = function(ctx, obj, path){
     if(!types.isMap(obj)){
         return null;
     }
-    obj = types.cleanNulls(obj);
     path = toKeyPath(path);
     return _.get(obj, path, null);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -793,7 +793,7 @@ stdlib.encode = function(ctx, val, indent){
     return types.encode(val, indent);
 };
 stdlib.keys = function(ctx, val, path){
-    if(!types.isMap(val)){
+    if(!types.isArrayOrMap(val)){
         return [];
     }
     if(path){
@@ -803,7 +803,7 @@ stdlib.keys = function(ctx, val, path){
     return _.keys(val);
 };
 stdlib.values = function(ctx, val, path){
-    if(!types.isMap(val)){
+    if(!types.isArrayOrMap(val)){
         return [];
     }
     if(path){
@@ -892,7 +892,7 @@ stdlib.unique = function(ctx, val){
 };
 
 stdlib["get"] = function(ctx, obj, path){
-    if(!types.isMap(obj)){
+    if(!types.isArrayOrMap(obj)){
         return null;
     }
     path = toKeyPath(path);
@@ -900,7 +900,7 @@ stdlib["get"] = function(ctx, obj, path){
 };
 
 stdlib["set"] = function(ctx, obj, path, val){
-    if(!types.isMap(obj)){
+    if(!types.isArrayOrMap(obj)){
         return obj;
     }
     path = toKeyPath(path);

--- a/src/index.js
+++ b/src/index.js
@@ -47,12 +47,15 @@ var stdlib = {};
 //Infix operators///////////////////////////////////////////////////////////////
 var ltEqGt = function(left, right){
     if(types.typeOf(left) !== types.typeOf(right)){
-        return NaN; //unlike -1/0/1, comparisons with 0 are false
+        return NaN; // unlike -1/0/1, all comparisons with 0 are false
     }
     left = types.cleanNulls(left);
     right = types.cleanNulls(right);
     if(_.isEqual(left, right)){
         return 0;
+    }
+    if(types.isArrayOrMap(left)){
+        return NaN; // don't compare unequal arrays or maps
     }
     return (left > right) ? 1 : -1;
 };
@@ -744,7 +747,7 @@ var isSafeArrayIndex = function(arr, key){
 
 stdlib.put = function(ctx, val, path, to_set){
     val = types.cleanNulls(val);
-    if(!types.isMap(val) || arguments.length < 3){
+    if(!types.isArrayOrMap(val) || arguments.length < 3){
         return val;
     }
     if(arguments.length < 4){

--- a/src/index.js
+++ b/src/index.js
@@ -33,91 +33,162 @@ var iterBase = function*(val, iter){
     }
 };
 
-
+// some guidelines/suggestions:
+// 0. effectively check arguments.length when not fixed by the grammar (and consider null versus omitted)
+// 1. convert NaN's/void 0's to nulls (if cleanNulls could possibly have an effect) for all return values and relevant arrays/maps
+// 2. don't mutate deep (array/map) arguments (cleanNulls doesn't, assignment can't)
+// 3. where strings/numbers/arrays are expected, convert to them when reasonable
+// 4. prioritize errors on val's type (if applicable), then argument values/types/0. from left to right
+// 5. try to return the logical noop value (e.g. false, [], val (without 3.'s changes)) for missing or unrecoverably wrongly typed arguments
+// 6. the wiki's docs take precedence over the above
 var stdlib = {};
 
 //Infix operators///////////////////////////////////////////////////////////////
 
 stdlib["<"] = function(ctx, left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    if(types.isArrayOrMap(left) && types.isArrayOrMap(right)){
+        return !_.isEqual(left, right) && [left, right].sort()[0] === left;
+    }
     return left < right;
 };
 stdlib[">"] = function(ctx, left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    if(types.isArrayOrMap(left) && types.isArrayOrMap(right)){
+        return !_.isEqual(left, right) && [left, right].sort()[0] === right;
+    }
     return left > right;
 };
 stdlib["<="] = function(ctx, left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    if(types.isArrayOrMap(left) && types.isArrayOrMap(right)){
+        return _.isEqual(left, right) || [left, right].sort()[0] === left;
+    }
     return left <= right;
 };
 stdlib[">="] = function(ctx, left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    if(types.isArrayOrMap(left) && types.isArrayOrMap(right)){
+        return _.isEqual(left, right) || [left, right].sort()[0] === right;
+    }
     return left >= right;
 };
 stdlib["=="] = function(ctx, left, right){
-    if(left === right){
-        return true;
-    }
-    return types.isNull(left) && types.isNull(right);
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    return _.isEqual(left, right);
 };
 stdlib["!="] = function(ctx, left, right){
-    if(left === right){
-        return false;
-    }
-    return !types.isNull(left) || !types.isNull(right);
+    return !stdlib["=="](ctx, left, right);
 };
 
-var isNumberLike = function(val){
-    return types.isNumber(val) || types.isNull(val) || val === false;
-};
 stdlib["+"] = function(ctx, left, right){
+    if(arguments.length < 3){
+        return types.cleanNulls(left);
+    }
     //if we have two "numbers" then do plus
-    if(isNumberLike(left) && isNumberLike(right)){
-        return (left || 0) + (right || 0);// `|| 0` converts null,NaN,false to 0
+    if(types.isNumber(left) && types.isNumber(right)){
+        return left + right;
     }
     //else do concat
     return types.toString(left) + types.toString(right);
 };
 stdlib["-"] = function(ctx, left, right){
+    var leftNumber = types.numericCast(left);
     if(arguments.length < 3){
-        return -left;
+        if(leftNumber === null){
+            throw new TypeError("Cannot negate " + types.toString(left));
+        }
+        return -types.cleanNulls(left);
     }
-    return left - right;
+    var rightNumber = types.numericCast(right);
+    if(leftNumber === null || rightNumber === null){
+        throw new TypeError(types.toString(right) + " cannot be subtracted from " + types.toString(left));
+    }
+    return leftNumber - rightNumber;
 };
 stdlib["*"] = function(ctx, left, right){
-    return left * right;
+    var leftNumber = types.numericCast(left);
+    var rightNumber = types.numericCast(right);
+    if(leftNumber === null || rightNumber === null){
+        throw new TypeError(types.toString(left) + " cannot be multiplied by " + types.toString(right));
+    }
+    return leftNumber * rightNumber;
 };
 stdlib["/"] = function(ctx, left, right){
-    return left / right;
+    var leftNumber = types.numericCast(left);
+    var rightNumber = types.numericCast(right);
+    if(leftNumber === null || rightNumber === null){
+        throw new TypeError(types.toString(left) + " cannot be divided by " + types.toString(right));
+    }
+    if(rightNumber === 0){
+        throw new RangeError(leftNumber + " / 0 is not a number");
+    }
+    return leftNumber / rightNumber;
 };
 stdlib["%"] = function(ctx, left, right){
-    return left % right;
+    var leftNumber = types.numericCast(left);
+    var rightNumber = types.numericCast(right);
+    if(leftNumber === null || rightNumber === null){
+        throw new TypeError("Cannot calculate " + types.toString(left) + " modulo " + types.toString(right));
+    }
+    if(rightNumber === 0){
+        return 0;
+    }
+    return leftNumber % rightNumber;
 };
 
 stdlib["><"] = function(ctx, obj, val){
+    var keys;
     if(types.isArray(obj)){
-        return _.indexOf(obj, val) >= 0;
+        keys = obj;
     }else if(types.isMap(obj)){
-        return _.indexOf(_.keys(obj), val) >= 0;
+        keys = _.keys(obj);
     }else{
+        keys = [obj];
+    }
+    return stdlib.index(ctx, keys, val) >= 0;
+};
+
+stdlib.like = function(ctx, val, regex){
+    if(types.isString(regex)){
+        regex = new RegExp(regex);
+    }else if(!types.isRegExp(regex)){
         return false;
     }
+    return regex.test(types.toString(val));
 };
 
-stdlib["like"] = function(ctx, val, regex){
-    if(!types.isRegExp(regex)){
-        return null;
-    }
-    return regex.test(val);
-};
-
-stdlib["<=>"] = stdlib["cmp"] = function(ctx, left, right){
-    if(stdlib["=="](ctx, left, right)){
+//left and right are already null-cleaned
+var ltEqGt = function(ctx, left, right){
+    if(_.isEqual(left, right)){
         return 0;
     }
-    return stdlib[">"](ctx, left, right)
-        ? 1
-        : -1;
+    if(types.isArrayOrMap(left) && types.isArrayOrMap(right)){
+        return [left, right].sort()[0] === right
+            ? 1
+            : -1;
+    }
+    return (left > right) ? 1 : -1;
+};
+stdlib["<=>"] = function(ctx, left, right){
+    var leftNumber = types.numericCast(left);
+    var rightNumber = types.numericCast(right);
+    if(leftNumber === null || rightNumber === null){
+        return ltEqGt(ctx, types.cleanNulls(left), types.cleanNulls(right));
+    }
+    return ltEqGt(ctx, leftNumber, rightNumber);
+};
+stdlib.cmp = function(ctx, left, right){
+    return ltEqGt(ctx, types.toString(left), types.toString(right));
 };
 
 stdlib.beesting = function(ctx, val){
-    return stdlib["as"](ctx, val, "String");
+    return stdlib.as(ctx, val, "String");
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -125,6 +196,9 @@ stdlib.beesting = function(ctx, val){
 //Operators
 //
 stdlib.as = function(ctx, val, type){
+    if(arguments.length < 3){
+        throw new Error("The .as() operator needs a type string");
+    }
     var val_type = types.typeOf(val);
     if(val_type === type){
         return val;
@@ -159,7 +233,7 @@ stdlib.as = function(ctx, val, type){
             return new RegExp(val);
         }
     }
-    throw new Error("Cannot use .as(\""+type+"\") operator with " + JSON.stringify(val) + " " + val_type);
+    throw new TypeError("Cannot use the .as(\""+type+"\") operator with " + types.toString(val) + " (type " + val_type + ")");
 };
 
 stdlib.isnull = function(ctx, val){
@@ -167,7 +241,12 @@ stdlib.isnull = function(ctx, val){
 };
 
 stdlib.klog = function(ctx, val, message){
-    ctx.emit("klog", val, message);
+    val = types.cleanNulls(val);
+    if(arguments.length < 3){
+        ctx.emit("klog", {val: val});
+    }else{
+        ctx.emit("klog", {val: val, message: types.cleanNulls(message)});
+    }
     return val;
 };
 
@@ -175,40 +254,71 @@ stdlib["typeof"] = function(ctx, val){
     return types.typeOf(val);
 };
 
+var format = function(val, template, specifier){
+    return _.join(
+        _.map(types.toString(template).split(/\\\\/g), function(v){
+            return v.replace(new RegExp("(^|[^\\\\])" + specifier, "g"), "$1" + val + "");
+        }),
+        "\\"
+    ).replace(new RegExp("\\\\" + specifier, "g"), specifier);
+};
+
 stdlib.sprintf = function(ctx, val, template){
+    if(arguments.length < 3){
+        return "";
+    }
+    template = types.cleanNulls(template);
     if(types.isNumber(val)){
-        return template.replace(/%d/g, val + "");
-    }else if(types.isString(val)){
-        return template.replace(/%s/g, val);
+        return format(val, template, "%d");
+    }
+    if(types.isString(val)){
+        return format(val, template, "%s");
     }
     return template;
 };
 
 stdlib.defaultsTo = function(ctx, val, defaultVal, message){
-    if(types.isNull(val)){
-        if(message !== void 0) ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
-        return defaultVal;
-    } else {
-        return val;
+    if(!types.isNull(val)){
+        return types.cleanNulls(val); // not important whether defaultVal is missing
     }
+    if(arguments.length < 3){
+        throw new Error("The .defaultsTo() operator needs a default value");
+    }
+    if(!types.isNull(message)) ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
+    return types.cleanNulls(defaultVal);
 };
 
 //Number operators//////////////////////////////////////////////////////////////
 stdlib.chr = function(ctx, val){
-    return String.fromCharCode(val);
+    var code = types.numericCast(val);
+    if(code === null){
+        return null;
+    }
+    return String.fromCharCode(code);
 };
 stdlib.range = function(ctx, val, end){
-    return _.range(val, end + 1);
+    var startNumber = types.numericCast(val);
+    var endNumber = types.numericCast(end);
+    if(startNumber === null || endNumber === null){
+        return []; // we could return [number] if one of them is a number
+    }
+    if(startNumber < endNumber){
+        return _.range(startNumber, endNumber + 1);
+    }
+    return _.range(startNumber, endNumber - 1);
 };
 
 //String operators//////////////////////////////////////////////////////////////
 stdlib.capitalize = function(ctx, val){
     val = types.toString(val);
+    if(val.length === 0){
+        return "";
+    }
     return val[0].toUpperCase() + val.slice(1);
 };
 stdlib.decode = function(ctx, val){
     if(!types.isString(val)){
-        return val;
+        return types.cleanNulls(val);
     }
     try{
         return JSON.parse(val);
@@ -217,7 +327,11 @@ stdlib.decode = function(ctx, val){
     }
 };
 stdlib.extract = function(ctx, val, regex){
+    if(arguments.length < 3){
+        return [];
+    }
     val = types.toString(val);
+    regex = types.cleanNulls(regex);
     var r = val.match(regex);
     if(!r){
         return [];
@@ -232,36 +346,53 @@ stdlib.lc = function(ctx, val){
     return val.toLowerCase();
 };
 stdlib.match = function(ctx, val, regex){
-    val = types.toString(val);
-    return regex.test(val);
+    if(types.isString(regex)){
+        regex = new RegExp(regex);
+    }else if(!types.isRegExp(regex)){
+        return false;
+    }
+    return regex.test(types.toString(val));
 };
 stdlib.ord = function(ctx, val){
     val = types.toString(val);
     var code = val.charCodeAt(0);
-    return _.isNaN(code) ? void 0 : code;
+    return _.isNaN(code) ? null : code;
 };
 stdlib.replace = function(ctx, val, regex, replacement){
+    if(arguments.length < 3){
+        return types.cleanNulls(val);
+    }
     val = types.toString(val);
-    return val.replace(regex, replacement);
+    if(!types.isString(regex) && !types.isRegExp(regex)){
+        regex = types.toString(regex);
+    }
+    if(types.isNull(replacement)){
+        return val.replace(regex, "");
+    }
+    return val.replace(regex, types.toString(replacement));
 };
 stdlib.split = function(ctx, val, split_on){
     val = types.toString(val);
+    split_on = types.cleanNulls(split_on);
     return val.split(split_on);
 };
 stdlib.substr = function(ctx, val, start, len){
+    start = types.numericCast(start);
+    if(start === null){
+        return types.cleanNulls(val);
+    }
     val = types.toString(val);
     if(start > val.length){
-        return;
+        return null;
     }
+    len = types.numericCast(len);
     var end;
-    if(len === void 0){
+    if(len === null){
         end = val.length;
+    }else if(len > 0){
+        end = start + len;
     }else{
-        if(len > 0){
-            end = start + len;
-        }else{
-            end = val.length + len;
-        }
+        end = val.length + len;
     }
     return val.substring(start, end);
 };
@@ -271,7 +402,15 @@ stdlib.uc = function(ctx, val){
 };
 
 //Collection operators//////////////////////////////////////////////////////////
+//operators using KRL functions are generators to be async-friendly (co library)
 stdlib.all = function*(ctx, val, iter){
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        val = [val];
+    }
+    if(!types.isFunction(iter)){
+        return val.length === 0;
+    }
     var broke = false;
     yield iterBase(val, function*(v, k, obj){
         var r = yield iter(ctx, [v, k, obj]);
@@ -284,9 +423,16 @@ stdlib.all = function*(ctx, val, iter){
     return !broke;
 };
 stdlib.notall = function*(ctx, val, iter){
-    return !(yield stdlib.all(ctx, val, iter));
+    return !(yield* stdlib.all(ctx, val, iter));
 };
 stdlib.any = function*(ctx, val, iter){
+    if(!types.isFunction(iter)){
+        return false;
+    }
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        val = [val];
+    }
     var broke = false;
     yield iterBase(val, function*(v, k, obj){
         var r = yield iter(ctx, [v, k, obj]);
@@ -299,12 +445,19 @@ stdlib.any = function*(ctx, val, iter){
     return broke;
 };
 stdlib.none = function*(ctx, val, iter){
-    return !(yield stdlib.any(ctx, val, iter));
+    return !(yield* stdlib.any(ctx, val, iter));
 };
 stdlib.append = function(ctx, val, others){
-    return _.concat.apply(void 0, _.tail(_.toArray(arguments)));
+    return _.concat.apply(void 0, types.cleanNulls(_.tail(_.toArray(arguments))));
 };
 stdlib.collect = function*(ctx, val, iter){
+    if(!types.isFunction(iter)){
+        return {};
+    }
+    val = types.cleanNulls(val);
+    if(!types.isArrayOrMap(val)){
+        val = [val];
+    }
     var grouped = {};
     yield iterBase(val, function*(v, k, obj){
         var r = yield iter(ctx, [v, k, obj]);
@@ -317,7 +470,14 @@ stdlib.collect = function*(ctx, val, iter){
     return grouped;
 };
 stdlib.filter = function*(ctx, val, iter){
-    var is_array = types.isArray(val);
+    val = types.cleanNulls(val);
+    if(!types.isFunction(iter)){
+        return val;
+    }
+    var is_array = !types.isMap(val);
+    if(is_array && !types.isArray(val)){
+        val = [val];
+    }
     var rslt = is_array ? [] : {};
     yield iterBase(val, function*(v, k, obj){
         var r = yield iter(ctx, [v, k, obj]);
@@ -333,22 +493,51 @@ stdlib.filter = function*(ctx, val, iter){
     return rslt;
 };
 stdlib.head = function(ctx, val){
-    return _.head(val);
+    if(!types.isArray(val)){
+        return types.cleanNulls(val); // head is for arrays; pretend val is a one-value array
+    }
+    return types.cleanNulls(val[0]);
 };
 stdlib.tail = function(ctx, val){
-    return _.tail(val);
+    if(!types.isArray(val)){
+        return [];
+    }
+    return types.cleanNulls(_.tail(val));
 };
 stdlib.index = function(ctx, val, elm){
-    return _.indexOf(val, elm);
+    val = types.cleanNulls(val);
+    elm = types.cleanNulls(elm);
+    if(!types.isArray(val)){
+        val = [val];
+    }
+    return _.findIndex(val, _.partial(_.isEqual, elm));
 };
 stdlib.join = function(ctx, val, str){
-    return _.join(val, str);
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        return val;
+    }
+    if(arguments.length < 3){
+        return _.join(val, ",");
+    }
+    return _.join(val, types.toString(str));
 };
+//works for maps for weak typing purposes
 stdlib.length = function(ctx, val){
-    return _.size(val);
+    if(types.isArrayOrMap(val) || types.isString(val)){
+        return _.size(val);
+    }
+    return 0; // we could check function.prototype.length
 };
 stdlib.map = function*(ctx, val, iter){
-    var is_array = types.isArray(val);
+    val = types.cleanNulls(val);
+    if(!types.isFunction(iter)){
+        return val;
+    }
+    var is_array = !types.isMap(val);
+    if(is_array && !types.isArray(val)){
+        val = [val];
+    }
     var rslt = is_array ? [] : {};
     yield iterBase(val, function*(v, k, obj){
         var r = yield iter(ctx, [v, k, obj]);
@@ -362,6 +551,24 @@ stdlib.map = function*(ctx, val, iter){
     return rslt;
 };
 stdlib.pairwise = function*(ctx, val, iter){
+    if(!types.isArray(val)){
+        throw new TypeError("The .pairwise() operator cannot be called on " + types.toString(val));
+    }
+    if(val.length < 2){
+        throw new TypeError("The .pairwise() operator needs a longer array");
+    }
+    if(arguments.length < 3){
+        throw new Error("The .pairwise() operator needs a function");
+    }
+    if(!types.isFunction(iter)){
+        throw new TypeError("The .pairwise() operator cannot use " + types.toString(iter) + " as a function");
+    }
+    val = _.map(val, function(v){
+        if(types.isArray(v)){
+            return v;
+        }
+        return [v];
+    });
     var max_len = _.max(_.map(val, _.size));
 
     var r = [];
@@ -372,24 +579,32 @@ stdlib.pairwise = function*(ctx, val, iter){
     for(i = 0; i < max_len; i++){
         args2 = [];
         for(j = 0; j < val.length; j++){
-            args2.push(val[j][i]);
+            args2.push(types.cleanNulls(val[j][i]));
         }
         r.push(yield iter(ctx, args2));
     }
     return r;
 };
 stdlib.reduce = function*(ctx, val, iter, dflt){
+    if(!types.isArray(val)){
+        val = [val];
+    }
     var no_default = arguments.length < 4;
-    if(_.size(val) === 0){
-        return no_default ? 0 : dflt;
+    if(val.length === 0){
+        return no_default ? 0 : types.cleanNulls(dflt);
     }
-    if(_.size(val) === 1){
+    if(!types.isFunction(iter) && (no_default || val.length > 1)){
+        throw new Error("The .reduce() operator cannot use " + types.toString(iter) + " as a function");
+    }
+    if(val.length === 1){
+        var head = types.cleanNulls(val[0]);
         if(no_default){
-            return _.head(val);
+            return head;
         }
-        return iter(ctx, [dflt, _.head(val)]);
+        return iter(ctx, [types.cleanNulls(dflt), head]);
     }
-    var acc = dflt;
+    val = types.cleanNulls(val);
+    var acc = types.cleanNulls(dflt);
     var is_first = true;
     yield iterBase(val, function*(v, k, obj){
         if(is_first && no_default){
@@ -403,52 +618,113 @@ stdlib.reduce = function*(ctx, val, iter, dflt){
     return acc;
 };
 stdlib.reverse = function(ctx, val){
-    return _.reverse(_.clone(val));
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        return val;
+    }
+    return _.reverse(val);
 };
 stdlib.slice = function(ctx, val, start, end){
-    if(start < 0 || start > _.size(val)){
-        return;
+    if(!types.isArray(val)){
+        val = [val];
+    }else if(val.length === 0){
+        ctx.emit("error", new Error("Cannot .slice() an empty array"));
+        return null;
     }
-    if(arguments.length < 4){
-        return _.slice(val, 0, start + 1);
+    if(arguments.length === 2){
+        return types.cleanNulls(val);
     }
-    if(end < 0 || end > _.size(val)){
-        return;
+    var firstIndex = types.numericCast(start);
+    if(firstIndex === null){
+        throw new TypeError("The .slice() operator cannot use " + types.toString(start) + " as an index");
     }
-    return _.slice(val, start, end + 1);
+    if(arguments.length === 3){
+        if(firstIndex > val.length){
+            ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from 0 to " + firstIndex));
+            return null;
+        }
+        return types.cleanNulls(_.slice(val, 0, firstIndex + 1));
+    }
+    var secondIndex = types.numericCast(end);
+    if(secondIndex === null){
+        throw new TypeError("The .slice() operator cannot use " + types.toString(end) + " as the other index");
+    }
+    if(firstIndex > secondIndex){ // this is why firstIndex isn't named startIndex
+        var temp = firstIndex;
+        firstIndex = secondIndex;
+        secondIndex = temp;
+    }
+    if(firstIndex >= 0 && secondIndex < val.length){
+        return types.cleanNulls(_.slice(val, firstIndex, secondIndex + 1));
+    }
+    ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from " + firstIndex + " to " + secondIndex));
+    return null;
 };
 stdlib.splice = function(ctx, val, start, n_elms, value){
-    var part1 = _.slice(val, 0, start);
-    var part2 = _.slice(val, start + n_elms);
+    if(!types.isArray(val)){
+        val = [val];
+    }else if(val.length === 0){
+        throw new Error("Cannot .splice() an empty array");
+    }
+    if(arguments.length < 4){
+        throw new Error("The .splice() operator needs more arguments");
+    }
+    var startIndex = types.numericCast(start);
+    if(startIndex === null){
+        throw new TypeError("The .splice() operator cannot use " + types.toString(start) + "as an index");
+    }
+    if(startIndex < 0){
+        throw new RangeError("Cannot start .splice() starting at index " + startIndex);
+    }
+    if(startIndex >= val.length){
+        throw new RangeError("Cannot .splice() an array of length " + val.length + " starting at index " + startIndex);
+    }
+    var n_elms_number = types.numericCast(n_elms);
+    if(n_elms_number === null){
+        throw new TypeError("The .splice() operator cannot use " + types.toString(n_elms) + "as a number of elements");
+    }
+    if(n_elms_number < 0 || startIndex + n_elms_number > val.length){
+        n_elms_number = val.length - startIndex;
+    }
+    var part1 = types.cleanNulls(_.slice(val, 0, startIndex));
+    var part2 = types.cleanNulls(_.slice(val, startIndex + n_elms));
     if(arguments.length < 5){
         return _.concat(part1, part2);
     }
-    return _.concat(part1, value, part2);
+    return _.concat(part1, types.cleanNulls(value), part2);
 };
 stdlib.sort = (function(){
-    var sorters = {
-        "numeric": function(a, b){
-            return a < b ? -1 : (a === b ? 0 : 1);
-        },
-        "ciremun": function(a, b){
-            return a < b ? 1 : (a === b ? 0 : -1);
-        }
-    };
     var swap = function(arr, i, j){
         var temp = arr[i];
         arr[i] = arr[j];
         arr[j] = temp;
     };
     return function*(ctx, val, sort_by){
-        if(sort_by === "reverse"){
-            //TODO optimize by making a "reverse" sorter function
-            return _.clone(val).sort().reverse();
-        }else if(_.has(sorters, sort_by)){
-            return _.clone(val).sort(sorters[sort_by]);
-        }else if(!types.isFunction(sort_by)){
-            return _.clone(val).sort();
+        val = types.cleanNulls(val);
+        if(!types.isArray(val)){
+            return val;
         }
-        var sorted = _.clone(val);
+        var sorters = {
+            "default": function(a, b){
+                return stdlib.cmp(ctx, a, b);
+            },
+            "reverse": function(a, b){
+                return -stdlib.cmp(ctx, a, b);
+            },
+            "numeric": function(a, b){
+                return stdlib["<=>"](ctx, a, b);
+            },
+            "ciremun": function(a, b){
+                return -stdlib["<=>"](ctx, a, b);
+            }
+        };
+        if(_.has(sorters, sort_by)){
+            return val.sort(sorters[sort_by]);
+        }
+        if(!types.isFunction(sort_by)){
+            return val.sort(sorters["default"]);
+        }
+        var sorted = val;
         var i, j, a, b;
         var len = sorted.length;
         for (i = len - 1; i >= 0; i--){
@@ -462,11 +738,11 @@ stdlib.sort = (function(){
         }
         return sorted;
     };
-}());
+})();
 stdlib["delete"] = function(ctx, val, path){
     path = toKeyPath(path);
     //TODO optimize
-    var n_val = _.cloneDeep(val);
+    var n_val = types.cleanNulls(val);
     _.unset(n_val, path);
     return n_val;
 };
@@ -480,10 +756,8 @@ var isSafeArrayIndex = function(arr, key){
 };
 
 stdlib.put = function(ctx, val, path, to_set){
-    if(!types.isMap(val) && !types.isArray(val)){
-        return val;
-    }
-    if(arguments.length < 3){
+    val = types.cleanNulls(val);
+    if(!types.isArrayOrMap(val) || arguments.length < 3){
         return val;
     }
     if(arguments.length < 4){
@@ -503,7 +777,7 @@ stdlib.put = function(ctx, val, path, to_set){
         }
         return to_set;
     }
-    var n_val = _.cloneDeep(val);
+    var n_val = val;
     var nested = n_val;
     var i, key;
     for(i = 0; i < path.length; i++){
@@ -534,67 +808,133 @@ stdlib.encode = function(ctx, val, indent){
     return types.encode(val, indent);
 };
 stdlib.keys = function(ctx, val, path){
+    if(!types.isMap(val)){
+        return [];
+    }
     if(path){
+        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.keys(_.get(val, path));
     }
     return _.keys(val);
 };
 stdlib.values = function(ctx, val, path){
+    if(!types.isMap(val)){
+        return [];
+    }
     if(path){
+        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.values(_.get(val, path));
     }
-    return _.values(val);
+    return types.cleanNulls(_.values(val));
 };
 stdlib.intersection = function(ctx, a, b){
-    return _.intersection(a, b);
+    if(arguments.length < 3){
+        return [];
+    }
+    a = types.cleanNulls(a);
+    if(!types.isArray(a)){
+        a = [a];
+    }
+    b = types.cleanNulls(b);
+    if(!types.isArray(b)){
+        b = [b];
+    }
+    return _.intersectionWith(a, b, _.isEqual);
 };
 stdlib.union = function(ctx, a, b){
+    a = types.cleanNulls(a);
+    if(arguments.length < 3){
+        return a;
+    }
+    if(!types.isArray(a)){
+        a = [a];
+    }
+    b = types.cleanNulls(b);
+    if(!types.isArray(b)){
+        b = [b];
+    }
     return _.unionWith(a, b, _.isEqual);
 };
 stdlib.difference = function(ctx, a, b){
+    a = types.cleanNulls(a);
+    if(arguments.length < 3){
+        return a;
+    }
+    if(!types.isArray(a)){
+        a = [a];
+    }
+    b = types.cleanNulls(b);
+    if(!types.isArray(b)){
+        b = [b];
+    }
     return _.differenceWith(a, b, _.isEqual);
 };
 stdlib.has = function(ctx, val, other){
-    return _.every(other, function(e){
-        return _.includes(val, e);
-    });
+    if(arguments.length < 3){
+        return true;
+    }
+    if(!types.isArray(val)){
+        val = [val];
+    }
+    return stdlib.difference(ctx, other, val).length === 0;
 };
 stdlib.once = function(ctx, val){
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        return val;
+    }
     //TODO optimize
     var r = [];
     _.each(_.groupBy(val), function(group){
-        if(_.size(group) === 1){
-            r.push(_.head(group));
+        if(group.length === 1){
+            r.push(group[0]);
         }
     });
     return r;
 };
 stdlib.duplicates = function(ctx, val){
+    if(!types.isArray(val)){
+        return [];
+    }
     //TODO optimize
     var r = [];
+    val = types.cleanNulls(val);
     _.each(_.groupBy(val), function(group){
-        if(_.size(group) > 1){
-            r.push(_.head(group));
+        if(group.length > 1){
+            r.push(group[0]);
         }
     });
     return r;
 };
 
 stdlib.unique = function(ctx, val){
+    val = types.cleanNulls(val);
+    if(!types.isArray(val)){
+        return val;
+    }
     return _.uniq(val);
 };
 
-stdlib["get"] = function(ctx, obj, path) {
+stdlib["get"] = function(ctx, obj, path){
+    if(!types.isMap(obj)){
+        return null;
+    }
+    obj = types.cleanNulls(obj);
     path = toKeyPath(path);
-    return _.get(obj,path);
+    return _.get(obj, path, null);
 };
 
-stdlib["set"] = function(ctx, obj, path, val) {
+stdlib["set"] = function(ctx, obj, path, val){
+    obj = types.cleanNulls(obj);
+    if(!types.isMap(obj)){
+        return obj;
+    }
     path = toKeyPath(path);
+    val = types.cleanNulls(val);
     //TODO optimize
-    return _.set(_.cloneDeep(obj), path, val);
+    return _.set(obj, path, val);
 };
 
 module.exports = stdlib;

--- a/src/index.js
+++ b/src/index.js
@@ -658,7 +658,7 @@ stdlib.splice = function(ctx, val, start, n_elms, value){
         throw new Error("Cannot .splice() an empty array");
     }
     if(arguments.length < 4){
-        throw new Error("The .splice() operator needs more arguments");
+        throw new Error("The .splice() operator needs more than one argument");
     }
     var startIndex = types.numericCast(start);
     if(startIndex === null){
@@ -905,7 +905,7 @@ stdlib.unique = function(ctx, val){
     if(!types.isArray(val)){
         return val;
     }
-    return _.uniq(val);
+    return _.uniqWith(val, _.isEqual);
 };
 
 stdlib["get"] = function(ctx, obj, path){

--- a/src/index.js
+++ b/src/index.js
@@ -502,9 +502,9 @@ stdlib.index = function(ctx, val, elm){
 };
 stdlib.join = function(ctx, val, str){
     if(!types.isArray(val)){
-        return val;
+        return types.toString(val);
     }
-    val = types.cleanNulls(val);
+    val = _.map(val, types.toString);
     if(arguments.length < 3){
         return _.join(val, ",");
     }

--- a/src/tests.js
+++ b/src/tests.js
@@ -391,6 +391,9 @@ test("string operators", function(t){
     tf("extract", ["This is a string", /(boot)/], []);
     tf("extract", ["I like cheese", /like (\w+)/], ["cheese"]);
     tf("extract", ["I like cheese", /(e)/g], ["e", "e", "e", "e"]);
+    tf("extract", ["I like cheese", "(ch.*)"], ["cheese"], "convert strings to RegExp");
+    tf("extract", ["what the null?", /null/], []);
+    tf("extract", ["what the null?", void 0], []);
 
     tf("lc", ["UppER"], "upper");
 

--- a/src/tests.js
+++ b/src/tests.js
@@ -4,6 +4,12 @@ var test = require("tape");
 var types = require("./types");
 var stdlib = require("./");
 
+//can't trust t.deepEqual(s)
+//see https://github.com/substack/tape/issues/186
+var deepEqual = function(t, actual, expected, message){
+    t.ok(_.isEqual(actual, expected), message || "should be equivalent");
+};
+
 var ylibFn = function(fn_name, args){
     args = [defaultCTX].concat(args);
     var fn = stdlib[fn_name];
@@ -24,6 +30,10 @@ var ylibFn = function(fn_name, args){
 var defaultCTX = {
     emit: _.noop
 };
+
+var action = function(){};
+action.is_an_action = true;
+
 //wrap lambdas as KRL Closures
 var mkClosure = function(args){
     return _.map(args, function(arg){
@@ -53,57 +63,19 @@ var testFn = function(t, fn, args, expected, emitType, errType, message){
 
     args = mkClosure(args);
     var emitCTX = mkCtx(emitType, errType);
-    t.deepEquals(stdlib[fn].apply(null, [emitCTX].concat(args)), expected, message);
+    deepEqual(t, stdlib[fn].apply(null, [emitCTX].concat(args)), expected, message);
 };
 
-var testFnErr = function(t, fn, args, type){
+var testFnErr = function(t, fn, args, type, message){
     args = mkClosure(args);
     try{
         stdlib[fn].apply(null, [defaultCTX].concat(args));
         t.fail("Failed to throw an error");
     }catch(err){
-        t.equals(err.name, type);
+        t.equals(err.name, type, message);
     }
 };
 
-var mkTf = function(t){
-    return function*(fn, args, expected, message){
-        args = _.map(args, function(arg){
-            if(cocb.isGeneratorFunction(arg)){
-                return function*(ctx, args){
-                    return yield arg.apply(this, args);
-                };
-            }else if(_.isFunction(arg)){
-                return cocb.toYieldable(function(ctx, args, callback){
-                    var data;
-                    try{
-                        data = arg.apply(this, args);
-                    }catch(err){
-                        callback(err);
-                        return;
-                    }
-                    callback(null, data);
-                });
-            }
-            return arg;
-        });
-        t.deepEquals(
-            yield ylibFn(fn, args),
-            expected,
-            message
-        );
-    };
-};
-
-var ytest = function(msg, body){
-    test(msg, function(t){
-        var tf = _.partial(testFn, t);
-        var tfe = _.partial(testFnErr, t);
-        var ytf = mkTf(t);
-        cocb.run(body(t, ytf, tfe, tf), t.end);
-    });
-};
-//use a fuzzer instead?
 var tfMatrix = function(tf, args, exp){
     var i;
     for(i=0; i < exp.length; i++){
@@ -114,8 +86,76 @@ var tfMatrix = function(tf, args, exp){
     }
 };
 
+var ytfMatrix = function*(ytf, obj, args, exp){
+    var i;
+    for(i=0; i < exp.length; i++){
+        var j;
+        for(j=0; j < args.length; j++){
+            yield ytf(exp[i][0], [obj, args[j]], exp[i][j+1]);
+        }
+    }
+};
+
+var mkTfMap = function(args){
+    return _.map(args, function(arg){
+        if(cocb.isGeneratorFunction(arg)){
+            return function*(ctx, args){
+                return yield arg.apply(this, args);
+            };
+        }else if(types.isFunction(arg)){
+            return cocb.toYieldable(function(ctx, args, callback){
+                var data;
+                try{
+                    data = arg.apply(this, args);
+                }catch(err){
+                    callback(err);
+                    return;
+                }
+                callback(null, data);
+            });
+        }
+        return arg;
+    });
+};
+
+var mkTf = function(t){
+    return function*(fn, args, expected, message){
+        args = mkTfMap(args);
+        deepEqual(
+            t,
+            yield ylibFn(fn, args),
+            expected,
+            message
+        );
+    };
+};
+
+var mkTfe = function(t){
+    return function*(fn, args, type, message){
+        args = mkTfMap(args);
+        try{
+            yield ylibFn(fn, args);
+            t.fail("Failed to throw an error");
+        }catch(err){
+            t.equals(err.name, type, message);
+        }
+    };
+};
+
+var ytest = function(msg, body){
+    test(msg, function(t){
+        var tf = _.partial(testFn, t);
+        var tfe = _.partial(testFnErr, t);
+        var ytf = mkTf(t);
+        var ytfe = mkTfe(t);
+        var ytfm = _.partial(ytfMatrix, ytf);
+        cocb.run(body(t, ytfm, ytfe, ytf, tfe, tf), t.end);
+    });
+};
+
 test("infix operators", function(t){
     var tf = _.partial(testFn, t);
+    var tfe = _.partial(testFnErr, t);
 
     tf("+", [1], 1);
     tf("+", [-1], -1);
@@ -132,13 +172,18 @@ test("infix operators", function(t){
     tf("+", ["wat", 100], "wat100");
     tf("+", [{}, []], "[Map][Array]");
 
+    tf("-", [2], -2);
+    tf("-", ["-2"], 2);
+    tfe("-", ["zero"], "TypeError");
+    tfe("-", [[0]], "TypeError");
+    tfe("-", [{}], "TypeError");
+
     tf("-", [1, 3], -2);
     tf("-", ["1", 3], -2);
     tf("-", [4, "1"], 3);
     tf("-", ["4", "1"], 3);
-    tf("-", [2], -2);
-    tf("-", ["-2"], 2);
-    //use t.throws replacement once written
+    tfe("-", ["two", 1], "TypeError");
+    tfe("-", [[], "-1"], "TypeError");
 
     tfMatrix(tf, [
         [2, 10],              // 1
@@ -162,36 +207,42 @@ test("infix operators", function(t){
     ]);
 
     tf("*", [5, 2], 10);
+    tfe("*", ["two", 1], "TypeError");
+    tfe("*", [[], "-1"], "TypeError");
+
     tf("/", [4, 2], 2);
+    tfe("/", ["two", 1], "TypeError");
+    tfe("/", [[], "-1"], "TypeError");
+    tfe("/", ["1", "0"], "RangeError");
+
     tf("%", [4, 2], 0);
-
-    tf("==", [2, 2], true);
-    tf("==", ["abc", "def"], false);
-    tf("==", ["abc", "abc"], true);
-    tf("==", [null, NaN], true);
-    tf("==", [NaN, undefined], true);
-    tf("==", [null, undefined], true);
-    tf("==", [NaN, NaN], true);
-
-    tf("!=", [1, 2], true);
-    tf("!=", [1, 1], false);
-    tf("!=", [1, NaN], true);
-    tf("!=", [null, NaN], false);
+    tf("%", ["1", "0"], 0);
+    tfe("%", [1, "two"], "TypeError");
+    tfe("%", [[], "-1"], "TypeError");
 
     tf("like", ["wat", /a/], true);
     tf("like", ["wat", /b/], false);
-    tf("like", ["wat"], false);
     tf("like", ["wat", "da"], false);
+    tf("like", ["wat", "a.*?(a|t)"], true);
 
-    tf("<=>", [5, 10], -1);
-    tf("<=>", [5, 5], 0);
-    tf("<=>", [10, 5], 1);
+    tf("<=>", ["5", "10"], -1);
+    tf("<=>", [5, "5"], 0);
+    tf("<=>", ["10", 5], 1);
+    tf("<=>", [{" ":-.5}, {" ":-.5}], 0);
     tf("<=>", [NaN, void 0], 0);
+    tfe("<=>", [null, 0], "TypeError");
+    tfe("<=>", [[0, 1], [1, 1]], "TypeError");
 
     tf("cmp", ["aab", "abb"], -1);
     tf("cmp", ["aab", "aab"], 0);
     tf("cmp", ["abb", "aab"], 1);
-    tf("cmp", [NaN, void 0], 0);
+    tf("cmp", [void 0, NaN], 0);
+    tf("cmp", ["5", "10"], 1);
+    tf("cmp", [5, "5"], 0);
+    tf("cmp", ["10", 5], -1);
+    tf("cmp", [{"":-.5}, {" ":.5}], 0);
+    tf("cmp", [[], [[""]]], 0);
+    tf("cmp", [null, 0], 1);
 
     t.end();
 });
@@ -199,6 +250,7 @@ test("infix operators", function(t){
 test("type operators", function(t){
 
     var tf = _.partial(testFn, t);
+    var tfe = _.partial(testFnErr, t);
 
     tf("as", [1, "String"], "1");
     tf("as", [.32, "String"], "0.32");
@@ -233,6 +285,10 @@ test("type operators", function(t){
     tf("as", ["true", "Boolean"], true);
     tf("as", ["false", "Boolean"], false);
     tf("as", [0, "Boolean"], false);
+    tf("as", [void 0], null);
+    tf("as", [[NaN, {"NaN":null}]], [null, {"NaN":null}]);
+    tfe("as", ["0", "num"], "TypeError");
+    tfe("as", [{}, /boolean/], "TypeError");
 
     tf("isnull", [], true);
     tf("isnull", [void 0], true);
@@ -275,8 +331,6 @@ test("type operators", function(t){
     t.equals(types.isMap({a: 1, b: 2}), true);
     t.equals(types.isMap(arguments), true);
 
-    var action = function(){};
-    action.is_an_action = true;
     t.equals(stdlib["typeof"](defaultCTX, action), "Action");
 
     t.end();
@@ -286,11 +340,21 @@ test("number operators", function(t){
     var tf = _.partial(testFn, t);
 
     tf("chr", [74], "J");
+    tf("chr", ["no"], null);
 
     tf("range", [0, 0], [0]);
-    tf("range", [0, 10], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    tf("range", ["0", 10], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    tf("range", [1, "-6"], [1, 0, -1, -2, -3, -4, -5, -6]);
+    tf("range", ["-1.5", "-3.5"], [-1.5, -2.5, -3.5]);
+    tf("range", [-4], []);
+    tf("range", [null, 0], []);
+    tf("range", [0, []], []);
 
-    tf("sprintf", [.25, "That is %d"], "That is 0.25");
+    tf("sprintf", [.25], "");
+    tf("sprintf", [.25, "That is %s"], "That is %s");
+    tf("sprintf", [.25, "%d = %d"], "0.25 = 0.25");
+    tf("sprintf", [.25, "\\%s%d\\\\n = .25%s"], "\\%s0.25\\n = .25%s");
+    tf("sprintf", [.25, "%\\d%d\\\\\\%dd\\n"], "%\\d0.25\\%dd\\n");
 
     t.end();
 });
@@ -298,16 +362,25 @@ test("number operators", function(t){
 test("string operators", function(t){
     var tf = _.partial(testFn, t);
 
-    tf("sprintf", ["Bob", "Hi %s!"], "Hi Bob!");
+    tf("sprintf", ["Bob"], "");
+    tf("sprintf", ["Bob", "Yo"], "Yo");
+    tf("sprintf", ["Bob", "%s is %s"], "Bob is Bob");
+    tf("sprintf", ["Bob", "\\%d%s\\\\n is Bob%d"], "\\%dBob\\n is Bob%d");
+    tf("sprintf", ["Bob", "%\\s%s\\\\\\%ss\\n"], "%\\sBob\\%ss\\n");
+    tf("sprintf", [_.noop, "Hi %s!"], "Hi %s!");
+    tf("sprintf", [{}, "Hey."], "Hey.");
 
     tf("capitalize", ["lower"], "Lower");
+    tf("capitalize", [""], "");
+    tf("capitalize", [" l"], " l");
 
     tf("decode", ["[1,2,3]"], [1, 2, 3]);
-    tf("decode", [[1,2,3]], [1, 2, 3], "if not a string, just return it");
+    tf("decode", [[1, 2, NaN]], [1, 2, null], "if not a string, return it (with the correct null)");
     tf("decode", [void 0], null, "if not a string, just return it (with the correct null)");
     tf("decode", ["[1,2"], "[1,2", "if parse fails, just return it");
     tf("decode", ["[1 2]"], "[1 2]", "if parse fails, just return it");
 
+    tf("extract", ["3 + 2 - 1"], []);
     tf("extract", ["3 + 2 - 1", /([0-9])/g], ["3", "2", "1"]);
     tf("extract", ["no-match", /([0-9])/g], []);
     tf("extract", ["This is a string", /(is)/], ["is"]);
@@ -318,29 +391,51 @@ test("string operators", function(t){
 
     tf("lc", ["UppER"], "upper");
 
-    tf("match", ["3 + 2 - 1", /([0-9])/g], true);
+    tf("match", ["3 + 2 - 1", "([0-9])"], true);
     tf("match", ["no-match", /([0-9])/g], false);
+    tf("match", ["1", 1], false);
+    tf("match", [0, /0/], true);
 
     tf("ord", [""], null);
     tf("ord", ["a"], 97);
     tf("ord", ["bill"], 98);
+    tf("ord", ["0"], 48);
 
-    tf("replace", ["William", /W/, "B"], "Billiam");
+    tf("replace", ["william W.", /W/i], "illiam W.");
+    tf("replace", ["William W.", /W/g, "B"], "Billiam B.");
+    tf("replace", ["Sa5m", 5, true], "Satruem");
+    tf("replace", [[false, void 0], /(?:)/ig], "[Array]");
+    tf("replace", [[false, void 0]], [false, null]);
 
     tf("split", ["a;b;3;4;", /;/], ["a", "b", "3", "4", ""]);
+    tf("split", ["a;b;3;4;", ""], ["a", ";", "b", ";", "3", ";", "4", ";"]);
+    tf("split", ["33a;b;3;4;", 3], ["", "", "a;b;", ";4;"]);
 
     tf("substr", ["This is a string", 5], "is a string");
-    tf("substr", ["This is a string", 5, 4], "is a");
-    tf("substr", ["This is a string", 5, -5], "is a s");
+    tf("substr", ["This is a string", 5, null], "is a string");
+    tf("substr", ["This is a string", 5, "4"], "is a");
+    tf("substr", ["This is a string", "5", -5], "is a s");
+    tf("substr", ["This is a string", "5", "-15"], "his ");
+    tf("substr", ["This is a string", 5, -18], "This ");
+    tf("substr", ["This is a string", 0, 25], "This is a string");
+    tf("substr", ["This is a string", 1, 25], "his is a string");
+    tf("substr", ["This is a string", 16, 0], "");
+    tf("substr", ["This is a string", 16, -1], "g");
     tf("substr", ["This is a string", 25], null);
+    tf("substr", [["Not a string", NaN]], ["Not a string", null]);
+    tf("substr", [void 0, "Not an index", 2], null);
 
     tf("uc", ["loWer"], "LOWER");
 
     t.end();
 });
 
-ytest("collection operators", function*(t, ytf, tfe, tf){
+ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
+    var deepEquals = _.partial(deepEqual, t);
+
     var a = [3, 4, 5];
+    var b = void 0;
+    var c = [];
 
     var obj = {
         "colors": "many",
@@ -349,76 +444,149 @@ ytest("collection operators", function*(t, ytf, tfe, tf){
     };
     var obj2 = {"a": 1, "b": 2, "c": 3};
     var assertObjNotMutated = function(){
-        t.deepEquals(obj, {
+        deepEquals(obj, {
             "colors": "many",
             "pi": [3, 1, 4, 1, 5, 9, 3],
             "foo": {"bar": {"10": "I like cheese"}}
         }, "should not be mutated");
-        t.deepEquals(obj2, {"a": 1, "b": 2, "c": 3}, "should not be mutated");
+        deepEquals(obj2, {"a": 1, "b": 2, "c": 3}, "should not be mutated");
     };
 
+    var fnDontCall = function(){
+        throw new Error();
+    };
+
+    tf("><", [obj, "many"], false);
     tf("><", [obj, "pi"], true);
-    tf("><", [obj, "a"], false);
+    tf("><", [obj, "bar"], false);
     assertObjNotMutated();
     tf("><", [[5, 6, 7], 6], true);
-    tf("><", [[5, 6, 7], 3], false);
-    tf("><", [{a: 1, b: 2}, "a"], true);
-    tf("><", [{a: 1, b: 2}, "foo"], false);
+    tf("><", [[5, 6, 7], 2], false);
+    tf("><", [[], null], false);
+    tf("><", [{}, void 0], false);
+    tf("><", [void 0, NaN], true);
 
-    var exp = [
-        ["all",     true, false, false],
-        ["notall", false,  true,  true],
-        ["any",     true,  true, false],
-        ["none",   false, false,  true]
-    ];
-    var i;
-    for(i=0; i < exp.length; i++){
-        yield ytf(exp[i][0], [a, function(x){return x < 10;}], exp[i][1]);
-        yield ytf(exp[i][0], [a, function(x){return x >  3;}], exp[i][2]);
-        yield ytf(exp[i][0], [a, function(x){return x > 10;}], exp[i][3]);
-        t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    }
+    yield ytfm(a, [
+        function(x){return x < 10;}, // 1
+        function(x){return x >  3;}, // 2
+        function(x){return x > 10;}, // 3
+        action,                      // 4
+    ], [            // 1      2      3      4
+        ["all",     true, false, false, false],
+        ["notall", false,  true,  true,  true],
+        ["any",     true,  true, false, false],
+        ["none",   false, false,  true,  true],
+    ]);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
 
-    tf("append", [a, [6]], [3, 4, 5, 6]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    tf("append", [["a", "b"], ["c", "d"]], ["a", "b", "c", "d"]);
+    yield ytfm(b, [
+        function(x){return stdlib.isnull({}, x);}, // 1
+        action,                                    // 2
+    ], [            // 1      2
+        ["all",     true, false],
+        ["notall", false,  true],
+        ["any",     true, false],
+        ["none",   false,  true],
+    ]);
+
+    yield ytfm(c, [
+        fnDontCall, // 1
+        action,     // 2
+    ], [            // 1      2
+        ["all",     true,  true],
+        ["notall", false, false],
+        ["any",    false, false],
+        ["none",    true,  true],
+    ]);
+    deepEquals(c, [], "should not be mutated");
+
+    tf("append", [["a", "b"], ["c", "a"]], ["a", "b", "c", "a"]);
     tf("append", [["a", "b"], 10, 11], ["a", "b", 10, 11]);
     tf("append", [10, 11], [10, 11]);
+    tf("append", [a, [6]], [3, 4, 5, 6]);
+    tf("append", [a, [[]]], [3, 4, 5, []]);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("append", [b, []], [null]);
+    tf("append", [b], [null]);
+    tf("append", [c, []], []);
+    tf("append", [c], []);
+    tf("append", [c, [[]]], [[]]);
+    deepEquals(c, [], "should not be mutated");
 
-    yield ytf("collect", [[7, 4, 3, 5, 2, 1, 6], function(a){
-        return (a < 5) ? "x" : "y";
-    }], {
+    var collectFn = function(a){
+        return stdlib["<"]({}, a, 5) ? "x" : "y";
+    };
+
+    yield ytf("collect", [[7, 4, 3, 5, 2, 1, 6], collectFn], {
         "x": [4,3,2,1],
         "y": [7,5,6]
     });
+    yield ytf("collect", [NaN, collectFn], {"y": [null]});
+    yield ytf("collect", [[], fnDontCall], {});
+    yield ytf("collect", [[7]], {});
+    yield ytf("collect", [[7], action], {});
+    //map tests
 
     yield ytf("filter", [a, function(x){return x < 5;}], [3, 4]);
-    yield ytf("filter", [a, function(x){return x !== 4;}], [3, 5]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
+    yield ytf("filter", [a, function(x){return x > 5;}], []);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    yield ytf("filter", [b, function(x){return stdlib.isnull({}, x);}], [null]);
+    yield ytf("filter", [c, fnDontCall], []);
+    deepEquals(c, [], "should not be mutated");
     yield ytf("filter", [obj2, function(v, k){return v < 3;}], {"a":1,"b":2});
     yield ytf("filter", [obj2, function(v, k){return k === "b";}], {"b":2});
     assertObjNotMutated();
+    yield ytf("filter", [b, action], null);
 
     tf("head", [a], 3);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("head", [[NaN, {}]], null);
+    tf("head", ["string"], "string");
+    tf("head", [{"0": NaN}], {"0": null});
     tf("head", [[]], null);
 
     tf("tail", [a], [4, 5]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    tf("tail", [[]], []);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("tail", [obj], []);
+    assertObjNotMutated();
+    tf("tail", ["string"], []);
 
     tf("index", [a, 5], 2);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("index", [b, NaN], 0);
+    tf("index", [obj, "colors"], -1);
+    tf("index", [obj2, 2], -1);
+    assertObjNotMutated();
+    tf("index", [c], -1);
+    deepEquals(c, [], "should not be mutated");
+    tf("index", [[[[0], 0], [0, [0]], [[0], 0], [0, [0]]], [0, [0]]], 1);
 
     tf("join", [a, ";"], "3;4;5");
     tf("join", [a], "3,4,5", "default to ,");
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("join", [b], null);
+    tf("join", [c, action], "");
+    deepEquals(c, [], "should not be mutated");
+    tf("join", [["<", ">"], /|/], "<re#|#>");
 
     tf("length", [a], 3);
+    tf("length", [[void 0, 7]], 2);
+    tf("length", ["\""], 1);
+    tf("length", [/'/], 0);
+    tf("length", [function(a,b){}], 0);
 
     yield ytf("map", [a, function(x){return x + 2;}], [5, 6, 7]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    yield ytf("map", [obj2, function(x){return x + 2;}], {"a":3,"b":4,"c":5});
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    yield ytf("map", [[3, 4, void 0]], [3, 4, null]);
+    yield ytf("map", [b, function(x){return x + "2";}], ["null2"]);
+    yield ytf("map", [action, action], action);
+    t.ok(types.isAction(action), "should not be mutated");
+    yield ytf("map", [c, fnDontCall], []);
+    deepEquals(c, [], "should not be mutated");
+    yield ytf("map", ["012", function(x){return x + "1";}], ["0121"], "strings are not character arrays");
+
+    yield ytf("map", [{}, fnDontCall], {});
+    yield ytf("map", [obj2, function(v, k){return v + k;}], {"a":"1a", "b":"2b","c":"3c"});
     assertObjNotMutated();
 
     yield ytf("pairwise", [[a, [6, 7, 8]], function(x, y){return x + y;}], [9, 11, 13]);
@@ -430,310 +598,316 @@ ytest("collection operators", function*(t, ytf, tfe, tf){
         "nulle",
         "nullf",
     ]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    yield ytf("pairwise", [[[], []], fnDontCall], []);
+    yield ytf("pairwise", [[[], 1], function(l, r){return [l, r];}], [[null, 1]]);
 
-    yield ytf("pairwise", [[[], []], function(l, r){return [l, r];}], []);
-    yield ytf("pairwise", [[[], [1]], function(l, r){return [l, r];}], [[null, 1]]);
-
-    yield ytf("reduce", [a, function(a,b){return a+b;}], 12);
-    yield ytf("reduce", [a, function(a,b){return a+b;}, 10], 22);
-    yield ytf("reduce", [a, function(a,b){return a-b;}], -6);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    yield ytf("reduce", [[], function(a,b){return a+b;}], 0);
-    yield ytf("reduce", [[], function(a,b){return a+b;}, 15], 15);
-    yield ytf("reduce", [[76], function(a,b){return a+b;}], 76);
-    yield ytf("reduce", [[76], function(a,b){return a+b;}, 15], 91);
-
-    tf("reverse", [a], [5, 4, 3]);
-    t.deepEquals(a, [3, 4, 5], "should not be mutated");
-
-    var vegies = ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"];
-    tf("slice", [vegies, 1, 4], ["tomato","tomato","tomato","sprouts"]);
-    tf("slice", [vegies, 2], ["corn","tomato","tomato"]);
-    tf("slice", [vegies, 0, 0], ["corn"]);
-    tf("slice", [[], -1], null, "error", "Error");
-    tf("slice", [vegies, 14], null, "error", "RangeError");
-
-    tf("splice", [vegies, 1, 4], ["corn","lettuce","sprouts"]);
-    tf("splice", [vegies, 2, 0, ["corn", "tomato"]], ["corn","tomato","corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"]);
-    tf("splice", [vegies, 2, 0, "liver"], ["corn","tomato","liver","tomato","tomato","sprouts","lettuce","sprouts"]);
-    tf("splice", [vegies, 2, 2, "liver"], ["corn","tomato","liver","sprouts","lettuce","sprouts"]);
-    tf("splice", [vegies, 1, 10], ["corn"]);
-    tf("splice", [vegies, 1, 10, "liver"], ["corn", "liver"]);
-    t.deepEquals(vegies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
-
-    var to_sort = [5, 3, 4, 1, 12];
-    yield ytf("sort", [to_sort], [1, 12, 3, 4, 5]);
-    yield ytf("sort", [to_sort, "reverse"], [5, 4, 3, 12, 1]);
-    yield ytf("sort", [to_sort, "numeric"], [1, 3, 4, 5, 12]);
-    yield ytf("sort", [to_sort, "ciremun"], [12, 5, 4, 3, 1]);
-    yield ytf("sort", [to_sort, function(a, b){
-        return a < b ? -1 : (a === b ? 0 : 1);
-    }], [1, 3, 4, 5, 12]);
-    t.deepEquals(to_sort, [5, 3, 4, 1, 12], "should not be mutated");
-
-    tf("delete", [obj, ["foo", "bar", 10]], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {"bar": {}}//or "foo": {} ???
-    });
-    assertObjNotMutated();
-
-    tf("encode", [{blah: 1}], "{\"blah\":1}");
-    tf("encode", [[1, 2]], "[1,2]");
-    tf("encode", [12], "12");
-    tf("encode", ["12"], "\"12\"");
-    //all nulls are treated the same
-    tf("encode", [null], "null");
-    tf("encode", [NaN], "null");
-    tf("encode", [void 0], "null");
-    //use .as("String") rules for other types
-    tf("encode", [_.noop], "\"[Function]\"");
-    tf("encode", [/a/ig], "\"re#a#gi\"");
-    (function(){
-        tf("encode", [arguments], "{\"0\":\"a\",\"1\":\"b\"}");
-    }("a", "b"));
-    //testing it nested
-    tf("encode", [{fn: _.noop, n: NaN, u: void 0}], "{\"fn\":\"[Function]\",\"n\":null,\"u\":null}");
-
-    //testing indent options
-    tf("encode", [{a: 1, b: 2}, 0], "{\"a\":1,\"b\":2}");
-    tf("encode", [{a: 1, b: 2}, 4], "{\n    \"a\": 1,\n    \"b\": 2\n}");
-    tf("encode", [{a: 1, b: 2}, "2"], "{\n  \"a\": 1,\n  \"b\": 2\n}");
-    tf("encode", [{a: 1, b: 2}, null], "{\"a\":1,\"b\":2}", "default indent to 0");
-    tf("encode", [{a: 1, b: 2}, arguments], "{\"a\":1,\"b\":2}", "default indent to 0");
-    tf("encode", [{a: 1, b: 2}, _.noop], "{\"a\":1,\"b\":2}", "default indent to 0");
-
-    tf("keys", [obj], ["colors", "pi", "foo"]);
-    tf("keys", [obj, ["foo", "bar"]], ["10"]);
-    assertObjNotMutated();
-
-    tf("values", [obj], [
-        "many",
-        [3, 1, 4, 1, 5, 9, 3],
-        {"bar": {"10": "I like cheese"}}
-    ]);
-    tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
-    assertObjNotMutated();
-
-    tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
-    tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
-    tf("put", [{key: 5}, ["baz"], {foo: "bar"}], {key: 5, baz: {foo: "bar"}});
-    tf("put", [{key: 5}, ["qux"], "wat?"], {key: 5, qux: "wat?"});
-    tf("put", [{key: 5}, [null], "wat?"], {key: 5, "null": "wat?"});
-    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
-    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
-    tf("put", [{key: 5}, [NaN], "wat?"], {key: 5, "null": "wat?"});
-    tf("put", [{key: 5}, [_.noop], "wat?"], {key: 5, "[Function]": "wat?"});
-
-    tf("put", [obj, ["foo"], {baz: "qux"}], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {"baz": "qux"},
-    }, "overwrite at the path, even if to_set and curr val are both maps");
-    tf("put", [obj, ["foo", "bar", 11], "wat?"], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {
-                "10": "I like cheese",
-                "11": "wat?",
-            },
-        }
-    });
-    tf("put", [obj, ["foo", "bar", 10], "no cheese"], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {"10": "no cheese"},
-        }
-    });
-    tf("put", [obj, {flop: 12}], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {"bar": {"10": "I like cheese"}},
-        "flop": 12
-    });
-    assertObjNotMutated();
-    tf("put", [{}, ["key1"], "value2"], {key1: "value2"});
-    tf("put", [{}, [], {key2: "value3"}], {key2: "value3"});
-    tf("put", [{key: 5}, "foo", {key2: "value3"}], {key: 5, "foo": {key2: "value3"}});
-    tf("put", [{key: 5}, "key", 7], {key: 7});
-    tf("put", [{key: 5}, ["key"], 9], {key: 9});
-
-    tf("put", [5, ["key"], 9], 5, "if val is not a Map or Array, return the val");
-    tf("put", ["wat", ["key"], 9], "wat", "if val is not a Map or Array, return the val");
-    tf("put", [null, ["key"], 9], null, "if val is not a Map or Array, return the val");
-
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {}, ["0", "0"], "foo")),
-        "{\"0\":{\"0\":\"foo\"}}",
-        "don't use arrays by default, i.e. don't do {\"0\":[\"foo\"]}"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {}, [0, 1], "foo")),
-        "{\"0\":{\"1\":\"foo\"}}",
-        "don't do {\"0\":[null,\"foo\"]}"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, [], [0, 0], "foo")),
-        "[{\"0\":\"foo\"}]"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, [["wat?"]], [0, 0], "foo")),
-        "[[\"foo\"]]",
-        "if the nested value is an array, keep it an array"
-    );
-
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {}, ["a", "b"], [])),
-        "{\"a\":{\"b\":[]}}",
-        "preserve type of to_set"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, [], [0], ["foo"])),
-        "[[\"foo\"]]",
-        "preserve type of to_set"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, [], [], ["foo"])),
-        "[\"foo\"]",
-        "preserve type of to_set"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", [0])),
-        "{\"foo\":[0]}",
-        "preserve type of to_set"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", ["bar"])),
-        "{\"foo\":[\"bar\"]}",
-        "preserve type of to_set"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, [{foo: 1}, {bar: 2}], [1, "bar", "baz"], 4)),
-        "[{\"foo\":1},{\"bar\":{\"baz\":4}}]"
-    );
-
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", 1], 4)),
-        "{\"one\":[2,4]}",
-        "number index"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "1"], 4)),
-        "{\"one\":[2,4]}",
-        "Array index can be a string"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "2"], 4)),
-        "{\"one\":[2,3,4]}",
-        "Array index at the end"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "3"], 4)),
-        "{\"one\":{\"0\":2,\"1\":3,\"3\":4}}",
-        "convert Array to Map if sparse array is attempted"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo"], 4)),
-        "{\"one\":{\"0\":2,\"1\":3,\"foo\":4}}",
-        "convert Array to Map if non-index path is given"
-    );
-    t.equals(
-        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo", "0"], 4)),
-        "{\"one\":{\"0\":2,\"1\":3,\"foo\":{\"0\":4}}}",
-        "convert Array to Map if non-index path is given"
-    );
-
-    tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
-    tf("get", [obj, "colors"], "many");
-    assertObjNotMutated();
-
-    tf("set", [obj, ["foo", "baz"], "qux"], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {"10": "I like cheese"},
-            "baz": "qux"
-        }
-    });
-    tf("set", [obj, "flop", 12], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {"10": "I like cheese"}
-        },
-        "flop": 12
-    });
-    tf("set", [obj, "colors", ["R", "G", "B"]], {
-        "colors": ["R", "G", "B"],
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {"10": "I like cheese"}
-        }
-    });
-    tf("set", [obj, ["foo", "bar", "10"], "modified a sub object"], {
-        "colors": "many",
-        "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {
-            "bar": {"10": "modified a sub object"}
-        }
-    });
-    assertObjNotMutated();
-
-    tf("intersection", [[2, 1], [2, 3]], [2]);
-
-    tf("union", [[2], [1, 2]], [2, 1]);
-    tf("union", [[1, 2], [1, 4]], [1, 2, 4]);
-    tf("union", [[{"x":2}], [{"x":1}, {"x":2}]], [{"x":2}, {"x":1}]);
-
-    tf("difference", [[2, 1], [2, 3]], [1]);
-    tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
-
-    tf("has", [[1, 2, 3, 4], [4, 2]], true);
-    tf("has", [[1, 2, 3, 4], [4, 5]], false);
-
-    tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
-
-    tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
-
-    tf("unique", [[1, 2, 1, 3, 4, 4]], [1, 2, 3, 4]);
+    yield ytfe("pairwise", [{}, fnDontCall], "TypeError");
+    yield ytfe("pairwise", [[[]], fnDontCall], "TypeError");
+    yield ytfe("pairwise", [[[], []]], "Error");
+    yield ytfe("pairwise", [[[], []], action], "TypeError");
+    //
+    //    yield ytf("reduce", [a, function(a,b){return a+b;}], 12);
+    //    yield ytf("reduce", [a, function(a,b){return a+b;}, 10], 22);
+    //    yield ytf("reduce", [a, function(a,b){return a-b;}], -6);
+    //    deepEquals(a, [3, 4, 5], "should not be mutated");
+    //    yield ytf("reduce", [[], function(a,b){return a+b;}], 0);
+    //    yield ytf("reduce", [[], function(a,b){return a+b;}, 15], 15);
+    //    yield ytf("reduce", [[76], function(a,b){return a+b;}], 76);
+    //    yield ytf("reduce", [[76], function(a,b){return a+b;}, 15], 91);
+    //
+    //    tf("reverse", [a], [5, 4, 3]);
+    //    deepEquals(a, [3, 4, 5], "should not be mutated");
+    //
+    //    var vegies = ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"];
+    //    tf("slice", [vegies, 1, 4], ["tomato","tomato","tomato","sprouts"]);
+    //    tf("slice", [vegies, 2], ["corn","tomato","tomato"]);
+    //    tf("slice", [vegies, 0, 0], ["corn"]);
+    //    tf("slice", [[], -1], null, "error", "Error");
+    //    tf("slice", [vegies, 14], null, "error", "RangeError");
+    //
+    //    tf("splice", [vegies, 1, 4], ["corn","lettuce","sprouts"]);
+    //    tf("splice", [vegies, 2, 0, ["corn", "tomato"]], ["corn","tomato","corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"]);
+    //    tf("splice", [vegies, 2, 0, "liver"], ["corn","tomato","liver","tomato","tomato","sprouts","lettuce","sprouts"]);
+    //    tf("splice", [vegies, 2, 2, "liver"], ["corn","tomato","liver","sprouts","lettuce","sprouts"]);
+    //    tf("splice", [vegies, 1, 10], ["corn"]);
+    //    tf("splice", [vegies, 1, 10, "liver"], ["corn", "liver"]);
+    //    deepEquals(vegies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
+    //
+    //    var to_sort = [5, 3, 4, 1, 12];
+    //    yield ytf("sort", [to_sort], [1, 12, 3, 4, 5]);
+    //    yield ytf("sort", [to_sort, "reverse"], [5, 4, 3, 12, 1]);
+    //    yield ytf("sort", [to_sort, "numeric"], [1, 3, 4, 5, 12]);
+    //    yield ytf("sort", [to_sort, "ciremun"], [12, 5, 4, 3, 1]);
+    //    yield ytf("sort", [to_sort, function(a, b){
+    //        return a < b ? -1 : (a === b ? 0 : 1);
+    //    }], [1, 3, 4, 5, 12]);
+    //    deepEquals(to_sort, [5, 3, 4, 1, 12], "should not be mutated");
+    //
+    //    tf("delete", [obj, ["foo", "bar", 10]], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {"bar": {}}//or "foo": {} ???
+    //    });
+    //    assertObjNotMutated();
+    //
+    //    tf("encode", [{blah: 1}], "{\"blah\":1}");
+    //    tf("encode", [[1, 2]], "[1,2]");
+    //    tf("encode", [12], "12");
+    //    tf("encode", ["12"], "\"12\"");
+    //    //all nulls are treated the same
+    //    tf("encode", [null], "null");
+    //    tf("encode", [NaN], "null");
+    //    tf("encode", [void 0], "null");
+    //    //use .as("String") rules for other types
+    //    tf("encode", [_.noop], "\"[Function]\"");
+    //    tf("encode", [/a/ig], "\"re#a#gi\"");
+    //    (function(){
+    //        tf("encode", [arguments], "{\"0\":\"a\",\"1\":\"b\"}");
+    //    }("a", "b"));
+    //    //testing it nested
+    //    tf("encode", [{fn: _.noop, n: NaN, u: void 0}], "{\"fn\":\"[Function]\",\"n\":null,\"u\":null}");
+    //
+    //    //testing indent options
+    //    tf("encode", [{a: 1, b: 2}, 0], "{\"a\":1,\"b\":2}");
+    //    tf("encode", [{a: 1, b: 2}, 4], "{\n    \"a\": 1,\n    \"b\": 2\n}");
+    //    tf("encode", [{a: 1, b: 2}, "2"], "{\n  \"a\": 1,\n  \"b\": 2\n}");
+    //    tf("encode", [{a: 1, b: 2}, null], "{\"a\":1,\"b\":2}", "default indent to 0");
+    //    tf("encode", [{a: 1, b: 2}, arguments], "{\"a\":1,\"b\":2}", "default indent to 0");
+    //    tf("encode", [{a: 1, b: 2}, _.noop], "{\"a\":1,\"b\":2}", "default indent to 0");
+    //
+    //    tf("keys", [obj], ["colors", "pi", "foo"]);
+    //    tf("keys", [obj, ["foo", "bar"]], ["10"]);
+    //    assertObjNotMutated();
+    //
+    //    tf("values", [obj], [
+    //        "many",
+    //        [3, 1, 4, 1, 5, 9, 3],
+    //        {"bar": {"10": "I like cheese"}}
+    //    ]);
+    //    tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
+    //    assertObjNotMutated();
+    //
+    //    tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
+    //    tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
+    //    tf("put", [{key: 5}, ["baz"], {foo: "bar"}], {key: 5, baz: {foo: "bar"}});
+    //    tf("put", [{key: 5}, ["qux"], "wat?"], {key: 5, qux: "wat?"});
+    //    tf("put", [{key: 5}, [null], "wat?"], {key: 5, "null": "wat?"});
+    //    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
+    //    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
+    //    tf("put", [{key: 5}, [NaN], "wat?"], {key: 5, "null": "wat?"});
+    //    tf("put", [{key: 5}, [_.noop], "wat?"], {key: 5, "[Function]": "wat?"});
+    //
+    //    tf("put", [obj, ["foo"], {baz: "qux"}], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {"baz": "qux"},
+    //    }, "overwrite at the path, even if to_set and curr val are both maps");
+    //    tf("put", [obj, ["foo", "bar", 11], "wat?"], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {
+    //                "10": "I like cheese",
+    //                "11": "wat?",
+    //            },
+    //        }
+    //    });
+    //    tf("put", [obj, ["foo", "bar", 10], "no cheese"], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {"10": "no cheese"},
+    //        }
+    //    });
+    //    tf("put", [obj, {flop: 12}], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {"bar": {"10": "I like cheese"}},
+    //        "flop": 12
+    //    });
+    //    assertObjNotMutated();
+    //    tf("put", [{}, ["key1"], "value2"], {key1: "value2"});
+    //    tf("put", [{}, [], {key2: "value3"}], {key2: "value3"});
+    //    tf("put", [{key: 5}, "foo", {key2: "value3"}], {key: 5, "foo": {key2: "value3"}});
+    //    tf("put", [{key: 5}, "key", 7], {key: 7});
+    //    tf("put", [{key: 5}, ["key"], 9], {key: 9});
+    //
+    //    tf("put", [5, ["key"], 9], 5, "if val is not a Map or Array, return the val");
+    //    tf("put", ["wat", ["key"], 9], "wat", "if val is not a Map or Array, return the val");
+    //    tf("put", [null, ["key"], 9], null, "if val is not a Map or Array, return the val");
+    //
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {}, ["0", "0"], "foo")),
+    //        "{\"0\":{\"0\":\"foo\"}}",
+    //        "don't use arrays by default, i.e. don't do {\"0\":[\"foo\"]}"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {}, [0, 1], "foo")),
+    //        "{\"0\":{\"1\":\"foo\"}}",
+    //        "don't do {\"0\":[null,\"foo\"]}"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, [], [0, 0], "foo")),
+    //        "[{\"0\":\"foo\"}]"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, [["wat?"]], [0, 0], "foo")),
+    //        "[[\"foo\"]]",
+    //        "if the nested value is an array, keep it an array"
+    //    );
+    //
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {}, ["a", "b"], [])),
+    //        "{\"a\":{\"b\":[]}}",
+    //        "preserve type of to_set"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, [], [0], ["foo"])),
+    //        "[[\"foo\"]]",
+    //        "preserve type of to_set"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, [], [], ["foo"])),
+    //        "[\"foo\"]",
+    //        "preserve type of to_set"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", [0])),
+    //        "{\"foo\":[0]}",
+    //        "preserve type of to_set"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", ["bar"])),
+    //        "{\"foo\":[\"bar\"]}",
+    //        "preserve type of to_set"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, [{foo: 1}, {bar: 2}], [1, "bar", "baz"], 4)),
+    //        "[{\"foo\":1},{\"bar\":{\"baz\":4}}]"
+    //    );
+    //
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", 1], 4)),
+    //        "{\"one\":[2,4]}",
+    //        "number index"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "1"], 4)),
+    //        "{\"one\":[2,4]}",
+    //        "Array index can be a string"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "2"], 4)),
+    //        "{\"one\":[2,3,4]}",
+    //        "Array index at the end"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "3"], 4)),
+    //        "{\"one\":{\"0\":2,\"1\":3,\"3\":4}}",
+    //        "convert Array to Map if sparse array is attempted"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo"], 4)),
+    //        "{\"one\":{\"0\":2,\"1\":3,\"foo\":4}}",
+    //        "convert Array to Map if non-index path is given"
+    //    );
+    //    t.equals(
+    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo", "0"], 4)),
+    //        "{\"one\":{\"0\":2,\"1\":3,\"foo\":{\"0\":4}}}",
+    //        "convert Array to Map if non-index path is given"
+    //    );
+    //
+    //    tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
+    //    tf("get", [obj, "colors"], "many");
+    //    assertObjNotMutated();
+    //
+    //    tf("set", [obj, ["foo", "baz"], "qux"], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {"10": "I like cheese"},
+    //            "baz": "qux"
+    //        }
+    //    });
+    //    tf("set", [obj, "flop", 12], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {"10": "I like cheese"}
+    //        },
+    //        "flop": 12
+    //    });
+    //    tf("set", [obj, "colors", ["R", "G", "B"]], {
+    //        "colors": ["R", "G", "B"],
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {"10": "I like cheese"}
+    //        }
+    //    });
+    //    tf("set", [obj, ["foo", "bar", "10"], "modified a sub object"], {
+    //        "colors": "many",
+    //        "pi": [3, 1, 4, 1, 5, 9, 3],
+    //        "foo": {
+    //            "bar": {"10": "modified a sub object"}
+    //        }
+    //    });
+    //    assertObjNotMutated();
+    //
+    //    tf("intersection", [[2, 1], [2, 3]], [2]);
+    //
+    //    tf("union", [[2], [1, 2]], [2, 1]);
+    //    tf("union", [[1, 2], [1, 4]], [1, 2, 4]);
+    //    tf("union", [[{"x":2}], [{"x":1}, {"x":2}]], [{"x":2}, {"x":1}]);
+    //
+    //    tf("difference", [[2, 1], [2, 3]], [1]);
+    //    tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
+    //
+    //    tf("has", [[1, 2, 3, 4], [4, 2]], true);
+    //    tf("has", [[1, 2, 3, 4], [4, 5]], false);
+    //
+    //    tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
+    //
+    //    tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
+    //
+    //    tf("unique", [[1, 2, 1, 3, 4, 4]], [1, 2, 3, 4]);
 });
 
-test("klog", function(t){
-    t.plan(3);
-    stdlib.klog({
-        emit: function(kind, obj){
-            t.equals(kind, "klog");
-            t.equals(obj.val, 42);
-            t.equals(obj.message, "message 1");
-        }
-    }, 42, "message 1");
-});
-
-test("defaultsTo - testing debug logging", function(t){
-
-    var messages = [];
-
-    var ctx = {
-        emit: function(kind, message){
-            t.equals(kind, "debug");
-
-            messages.push(message);
-        }
-    };
-
-    t.equals(stdlib.defaultsTo(ctx, "not needed", 42, "message 2"), "not needed");
-    t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
-    t.equals(stdlib.defaultsTo(ctx, null, 42, "message 2"), 42, "should emit debug");
-    t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
-    t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
-
-    t.deepEquals(messages, [
-        "[DEFAULTSTO] message 2",
-        "[DEFAULTSTO] [Function]",//message should use KRL toString rules
-    ]);
-
-    t.end();
-});
+//test("klog", function(t){
+//    t.plan(4);
+//    var val = 42;
+//    t.equals(stdlib.klog({
+//        emit: function(kind, obj){
+//            t.equals(kind, "klog");
+//            t.equals(obj.val, 42);
+//            t.equals(obj.message, "message 1");
+//        }
+//    }, val, "message 1"), val);
+//});
+//
+//test("defaultsTo - testing debug logging", function(t){
+//
+//    var messages = [];
+//
+//    var ctx = {
+//        emit: function(kind, message){
+//            t.equals(kind, "debug");
+//
+//            messages.push(message);
+//        }
+//    };
+//
+//    t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
+//    t.equals(stdlib.defaultsTo(ctx, null, NaN, "message 1"), null, "should emit debug");
+//    t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
+//    t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
+//    deepEqual(t, stdlib.defaultsTo(ctx, [void 0]), [null]);
+//    testFnErr(t, "defaultsTo", [null], "Error");
+//
+//    deepEquals(t, messages, [
+//        "[DEFAULTSTO] message 1",
+//        "[DEFAULTSTO] [Function]",//message should use KRL toString rules
+//    ]);
+//
+//    t.end();
+//});

--- a/src/tests.js
+++ b/src/tests.js
@@ -897,8 +897,8 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("difference", [[2, 1], [2, 3]], [1]);
     tf("difference", [[2, 1], 2], [1]);
     tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
-    tf("difference", [{"x":NaN}, []], [{"x":null}]);
-    tf("difference", [{"x":NaN}], {"x":null});
+    tf("difference", [{"x":null}, []], [{"x":null}]);
+    tf("difference", [{"x":null}], {"x":null});
 
     tf("has", [[1, 2, 3, 4], [4, 2]], true);
     tf("has", [[1, 2, 3, 4], [4, 5]], false);
@@ -941,7 +941,7 @@ test("defaultsTo - testing debug logging", function(t){
     };
 
     t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
-    t.equals(stdlib.defaultsTo(ctx, null, NaN, "message 1"), null, "should emit debug");
+    t.ok(_.isNaN(stdlib.defaultsTo(ctx, null, NaN, "message 1")), "should emit debug");
     t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
     t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
     t.deepEqual(stdlib.defaultsTo(ctx, [void 0]), [void 0]);

--- a/src/tests.js
+++ b/src/tests.js
@@ -74,7 +74,16 @@ var ytest = function(msg, body){
         cocb.run(body(t, ytf, tf), t.end);
     });
 };
-
+//use a fuzzer instead?
+var tfMatrix = function(tf, args, exp){
+    var i;
+    for(i=0; i < exp.length; i++){
+        var j;
+        for(j=0; j < args.length; j++){
+            tf(exp[i][0], args[j], exp[i][j+1]);
+        }
+    }
+};
 
 test("infix operators", function(t){
     var tf = _.partial(testFn, t);
@@ -96,10 +105,28 @@ test("infix operators", function(t){
 
     tf("-", [1, 3], -2);
     tf("-", [4, 1], 3);
-    tf("-", [2], -2);
+    tf("-", [2], -2);//t15
 
-    tf("<", [1, 3], true);
-    tf("<", [3, 1], false);
+    tfMatrix(tf, [
+        [2, 10],              // 1
+        [6, 6],               // 2
+        [10, 2],              // 3
+        ["2", "10"],          // 4
+        ["6", "6"],           // 5
+        ["10", "2"],          // 6
+        [NaN, null],          // 7
+        [["a", 0], ["a", 0]], // 8
+        [{"a": 0}, {"a": 0}], // 9
+        [["a", 0], ["b", 1]], // 10
+        [{"a": 1}, {"b": 0}], // 11
+    ], [        // 1      2      3      4      5      6      7      8      9     10     11
+        ["<",   true, false, false, false, false,  true, false, false, false, false, false],///FIX
+        [">",  false, false,  true,  true, false, false, false, false, false, false, false],
+        ["<=",  true,  true, false, false,  true,  true,  true,  true,  true, false, false],
+        [">=", false,  true,  true,  true,  true, false,  true,  true,  true, false, false],
+        ["==", false,  true, false, false,  true, false,  true,  true,  true, false, false],
+        ["!=",  true, false,  true,  true, false,  true, false, false, false,  true,  true],
+    ]);
 
     tf("*", [5, 2], 10);
     tf("/", [4, 2], 2);

--- a/src/tests.js
+++ b/src/tests.js
@@ -37,7 +37,7 @@ action.is_an_action = true;
 //wrap lambdas as KRL Closures
 var mkClosure = function(args){
     return _.map(args, function(arg){
-        if(_.isFunction(arg)){
+        if(types.isFunction(arg)){
             return function(ctx, args){
                 return arg.apply(this, args);
             };
@@ -375,8 +375,8 @@ test("string operators", function(t){
     tf("capitalize", [" l"], " l");
 
     tf("decode", ["[1,2,3]"], [1, 2, 3]);
-    tf("decode", [[1, 2, NaN]], [1, 2, null], "if not a string, return it (with the correct null)");
-    tf("decode", [void 0], null, "if not a string, just return it (with the correct null)");
+    tf("decode", [[1, 2, NaN]], [1, 2, null], "if not a string, return it (with the correct nulls)");
+    tf("decode", [void 0], null, "if not a string, just return it (with the correct nulls)");
     tf("decode", ["[1,2"], "[1,2", "if parse fails, just return it");
     tf("decode", ["[1 2]"], "[1 2]", "if parse fails, just return it");
 
@@ -583,7 +583,7 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     t.ok(types.isAction(action), "should not be mutated");
     yield ytf("map", [c, fnDontCall], []);
     deepEquals(c, [], "should not be mutated");
-    yield ytf("map", ["012", function(x){return x + "1";}], ["0121"], "strings are not character arrays");
+    yield ytf("map", ["012", function(x){return x + "1";}], ["0121"], "KRL strings are not arrays");
 
     yield ytf("map", [{}, fnDontCall], {});
     yield ytf("map", [obj2, function(v, k){return v + k;}], {"a":"1a", "b":"2b","c":"3c"});
@@ -606,308 +606,347 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     yield ytfe("pairwise", [[[]], fnDontCall], "TypeError");
     yield ytfe("pairwise", [[[], []]], "Error");
     yield ytfe("pairwise", [[[], []], action], "TypeError");
-    //
-    //    yield ytf("reduce", [a, function(a,b){return a+b;}], 12);
-    //    yield ytf("reduce", [a, function(a,b){return a+b;}, 10], 22);
-    //    yield ytf("reduce", [a, function(a,b){return a-b;}], -6);
-    //    deepEquals(a, [3, 4, 5], "should not be mutated");
-    //    yield ytf("reduce", [[], function(a,b){return a+b;}], 0);
-    //    yield ytf("reduce", [[], function(a,b){return a+b;}, 15], 15);
-    //    yield ytf("reduce", [[76], function(a,b){return a+b;}], 76);
-    //    yield ytf("reduce", [[76], function(a,b){return a+b;}, 15], 91);
-    //
-    //    tf("reverse", [a], [5, 4, 3]);
-    //    deepEquals(a, [3, 4, 5], "should not be mutated");
-    //
-    //    var vegies = ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"];
-    //    tf("slice", [vegies, 1, 4], ["tomato","tomato","tomato","sprouts"]);
-    //    tf("slice", [vegies, 2], ["corn","tomato","tomato"]);
-    //    tf("slice", [vegies, 0, 0], ["corn"]);
-    //    tf("slice", [[], -1], null, "error", "Error");
-    //    tf("slice", [vegies, 14], null, "error", "RangeError");
-    //
-    //    tf("splice", [vegies, 1, 4], ["corn","lettuce","sprouts"]);
-    //    tf("splice", [vegies, 2, 0, ["corn", "tomato"]], ["corn","tomato","corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"]);
-    //    tf("splice", [vegies, 2, 0, "liver"], ["corn","tomato","liver","tomato","tomato","sprouts","lettuce","sprouts"]);
-    //    tf("splice", [vegies, 2, 2, "liver"], ["corn","tomato","liver","sprouts","lettuce","sprouts"]);
-    //    tf("splice", [vegies, 1, 10], ["corn"]);
-    //    tf("splice", [vegies, 1, 10, "liver"], ["corn", "liver"]);
-    //    deepEquals(vegies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
-    //
-    //    var to_sort = [5, 3, 4, 1, 12];
-    //    yield ytf("sort", [to_sort], [1, 12, 3, 4, 5]);
-    //    yield ytf("sort", [to_sort, "reverse"], [5, 4, 3, 12, 1]);
-    //    yield ytf("sort", [to_sort, "numeric"], [1, 3, 4, 5, 12]);
-    //    yield ytf("sort", [to_sort, "ciremun"], [12, 5, 4, 3, 1]);
-    //    yield ytf("sort", [to_sort, function(a, b){
-    //        return a < b ? -1 : (a === b ? 0 : 1);
-    //    }], [1, 3, 4, 5, 12]);
-    //    deepEquals(to_sort, [5, 3, 4, 1, 12], "should not be mutated");
-    //
-    //    tf("delete", [obj, ["foo", "bar", 10]], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {"bar": {}}//or "foo": {} ???
-    //    });
-    //    assertObjNotMutated();
-    //
-    //    tf("encode", [{blah: 1}], "{\"blah\":1}");
-    //    tf("encode", [[1, 2]], "[1,2]");
-    //    tf("encode", [12], "12");
-    //    tf("encode", ["12"], "\"12\"");
-    //    //all nulls are treated the same
-    //    tf("encode", [null], "null");
-    //    tf("encode", [NaN], "null");
-    //    tf("encode", [void 0], "null");
-    //    //use .as("String") rules for other types
-    //    tf("encode", [_.noop], "\"[Function]\"");
-    //    tf("encode", [/a/ig], "\"re#a#gi\"");
-    //    (function(){
-    //        tf("encode", [arguments], "{\"0\":\"a\",\"1\":\"b\"}");
-    //    }("a", "b"));
-    //    //testing it nested
-    //    tf("encode", [{fn: _.noop, n: NaN, u: void 0}], "{\"fn\":\"[Function]\",\"n\":null,\"u\":null}");
-    //
-    //    //testing indent options
-    //    tf("encode", [{a: 1, b: 2}, 0], "{\"a\":1,\"b\":2}");
-    //    tf("encode", [{a: 1, b: 2}, 4], "{\n    \"a\": 1,\n    \"b\": 2\n}");
-    //    tf("encode", [{a: 1, b: 2}, "2"], "{\n  \"a\": 1,\n  \"b\": 2\n}");
-    //    tf("encode", [{a: 1, b: 2}, null], "{\"a\":1,\"b\":2}", "default indent to 0");
-    //    tf("encode", [{a: 1, b: 2}, arguments], "{\"a\":1,\"b\":2}", "default indent to 0");
-    //    tf("encode", [{a: 1, b: 2}, _.noop], "{\"a\":1,\"b\":2}", "default indent to 0");
-    //
-    //    tf("keys", [obj], ["colors", "pi", "foo"]);
-    //    tf("keys", [obj, ["foo", "bar"]], ["10"]);
-    //    assertObjNotMutated();
-    //
-    //    tf("values", [obj], [
-    //        "many",
-    //        [3, 1, 4, 1, 5, 9, 3],
-    //        {"bar": {"10": "I like cheese"}}
-    //    ]);
-    //    tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
-    //    assertObjNotMutated();
-    //
-    //    tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
-    //    tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
-    //    tf("put", [{key: 5}, ["baz"], {foo: "bar"}], {key: 5, baz: {foo: "bar"}});
-    //    tf("put", [{key: 5}, ["qux"], "wat?"], {key: 5, qux: "wat?"});
-    //    tf("put", [{key: 5}, [null], "wat?"], {key: 5, "null": "wat?"});
-    //    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
-    //    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
-    //    tf("put", [{key: 5}, [NaN], "wat?"], {key: 5, "null": "wat?"});
-    //    tf("put", [{key: 5}, [_.noop], "wat?"], {key: 5, "[Function]": "wat?"});
-    //
-    //    tf("put", [obj, ["foo"], {baz: "qux"}], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {"baz": "qux"},
-    //    }, "overwrite at the path, even if to_set and curr val are both maps");
-    //    tf("put", [obj, ["foo", "bar", 11], "wat?"], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {
-    //                "10": "I like cheese",
-    //                "11": "wat?",
-    //            },
-    //        }
-    //    });
-    //    tf("put", [obj, ["foo", "bar", 10], "no cheese"], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {"10": "no cheese"},
-    //        }
-    //    });
-    //    tf("put", [obj, {flop: 12}], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {"bar": {"10": "I like cheese"}},
-    //        "flop": 12
-    //    });
-    //    assertObjNotMutated();
-    //    tf("put", [{}, ["key1"], "value2"], {key1: "value2"});
-    //    tf("put", [{}, [], {key2: "value3"}], {key2: "value3"});
-    //    tf("put", [{key: 5}, "foo", {key2: "value3"}], {key: 5, "foo": {key2: "value3"}});
-    //    tf("put", [{key: 5}, "key", 7], {key: 7});
-    //    tf("put", [{key: 5}, ["key"], 9], {key: 9});
-    //
-    //    tf("put", [5, ["key"], 9], 5, "if val is not a Map or Array, return the val");
-    //    tf("put", ["wat", ["key"], 9], "wat", "if val is not a Map or Array, return the val");
-    //    tf("put", [null, ["key"], 9], null, "if val is not a Map or Array, return the val");
-    //
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {}, ["0", "0"], "foo")),
-    //        "{\"0\":{\"0\":\"foo\"}}",
-    //        "don't use arrays by default, i.e. don't do {\"0\":[\"foo\"]}"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {}, [0, 1], "foo")),
-    //        "{\"0\":{\"1\":\"foo\"}}",
-    //        "don't do {\"0\":[null,\"foo\"]}"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, [], [0, 0], "foo")),
-    //        "[{\"0\":\"foo\"}]"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, [["wat?"]], [0, 0], "foo")),
-    //        "[[\"foo\"]]",
-    //        "if the nested value is an array, keep it an array"
-    //    );
-    //
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {}, ["a", "b"], [])),
-    //        "{\"a\":{\"b\":[]}}",
-    //        "preserve type of to_set"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, [], [0], ["foo"])),
-    //        "[[\"foo\"]]",
-    //        "preserve type of to_set"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, [], [], ["foo"])),
-    //        "[\"foo\"]",
-    //        "preserve type of to_set"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", [0])),
-    //        "{\"foo\":[0]}",
-    //        "preserve type of to_set"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", ["bar"])),
-    //        "{\"foo\":[\"bar\"]}",
-    //        "preserve type of to_set"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, [{foo: 1}, {bar: 2}], [1, "bar", "baz"], 4)),
-    //        "[{\"foo\":1},{\"bar\":{\"baz\":4}}]"
-    //    );
-    //
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", 1], 4)),
-    //        "{\"one\":[2,4]}",
-    //        "number index"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "1"], 4)),
-    //        "{\"one\":[2,4]}",
-    //        "Array index can be a string"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "2"], 4)),
-    //        "{\"one\":[2,3,4]}",
-    //        "Array index at the end"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "3"], 4)),
-    //        "{\"one\":{\"0\":2,\"1\":3,\"3\":4}}",
-    //        "convert Array to Map if sparse array is attempted"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo"], 4)),
-    //        "{\"one\":{\"0\":2,\"1\":3,\"foo\":4}}",
-    //        "convert Array to Map if non-index path is given"
-    //    );
-    //    t.equals(
-    //        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo", "0"], 4)),
-    //        "{\"one\":{\"0\":2,\"1\":3,\"foo\":{\"0\":4}}}",
-    //        "convert Array to Map if non-index path is given"
-    //    );
-    //
-    //    tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
-    //    tf("get", [obj, "colors"], "many");
-    //    assertObjNotMutated();
-    //
-    //    tf("set", [obj, ["foo", "baz"], "qux"], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {"10": "I like cheese"},
-    //            "baz": "qux"
-    //        }
-    //    });
-    //    tf("set", [obj, "flop", 12], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {"10": "I like cheese"}
-    //        },
-    //        "flop": 12
-    //    });
-    //    tf("set", [obj, "colors", ["R", "G", "B"]], {
-    //        "colors": ["R", "G", "B"],
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {"10": "I like cheese"}
-    //        }
-    //    });
-    //    tf("set", [obj, ["foo", "bar", "10"], "modified a sub object"], {
-    //        "colors": "many",
-    //        "pi": [3, 1, 4, 1, 5, 9, 3],
-    //        "foo": {
-    //            "bar": {"10": "modified a sub object"}
-    //        }
-    //    });
-    //    assertObjNotMutated();
-    //
-    //    tf("intersection", [[2, 1], [2, 3]], [2]);
-    //
-    //    tf("union", [[2], [1, 2]], [2, 1]);
-    //    tf("union", [[1, 2], [1, 4]], [1, 2, 4]);
-    //    tf("union", [[{"x":2}], [{"x":1}, {"x":2}]], [{"x":2}, {"x":1}]);
-    //
-    //    tf("difference", [[2, 1], [2, 3]], [1]);
-    //    tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
-    //
-    //    tf("has", [[1, 2, 3, 4], [4, 2]], true);
-    //    tf("has", [[1, 2, 3, 4], [4, 5]], false);
-    //
-    //    tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
-    //
-    //    tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
-    //
-    //    tf("unique", [[1, 2, 1, 3, 4, 4]], [1, 2, 3, 4]);
+
+    yield ytf("reduce", [a, function(a,b){return a+b;}], 12);
+    yield ytf("reduce", [a, function(a,b){return a+b;}, 10], 22);
+    yield ytf("reduce", [a, function(a,b){return a-b;}], -6);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    yield ytf("reduce", [[], fnDontCall], 0);
+    yield ytf("reduce", [[], fnDontCall, void 0], null);
+    yield ytf("reduce", [76, fnDontCall], 76);
+    yield ytf("reduce", [null, function(a,b){return a+b;}, "76"], "76null");
+
+    tf("reverse", [a], [5, 4, 3]);
+    deepEquals(a, [3, 4, 5], "should not be mutated");
+    tf("reverse", ["not an array"], "not an array");
+
+    var veggies = ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"];
+    tf("slice", [veggies, 1, 4], ["tomato","tomato","tomato","sprouts"]);
+    tf("slice", [veggies, 2, 0], ["corn","tomato","tomato"]);
+    tf("slice", [veggies, 2], ["corn","tomato","tomato"]);
+    tf("slice", [veggies, 0, 0], ["corn"]);
+    tf("slice", [{"0": "0"}, 0, 0], [{"0": "0"}]);
+    tf("slice", [[], _.noop], null, "error", "Error");
+    tfe("slice", [veggies, _.noop], "TypeError");
+    tfe("slice", [veggies, 1, _.noop], "TypeError");
+    tfe("slice", [veggies, -1, _.noop], "TypeError");
+    tf("slice", [veggies, 14], null, "error", "RangeError");
+    tf("slice", [veggies, 2, -1], null, "error", "RangeError");
+    deepEquals(veggies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
+
+    tf("splice", [veggies, 1, 4], ["corn","lettuce","sprouts"]);
+    tf("splice", [veggies, 2, 0, ["corn", "tomato"]], ["corn","tomato","corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"]);
+    tf("splice", [veggies, 2, 0, "liver"], ["corn","tomato","liver","tomato","tomato","sprouts","lettuce","sprouts"]);
+    tf("splice", [veggies, 2, 2, "liver"], ["corn","tomato","liver","sprouts","lettuce","sprouts"]);
+    tf("splice", [veggies, 1, 10], ["corn"]);
+    tf("splice", [veggies, 1, 10, "liver"], ["corn", "liver"]);
+    tf("splice", [veggies, 1, 10, []], ["corn"]);
+    tfe("splice", [[], NaN], "Error");
+    tfe("splice", [void 0, NaN, []], "TypeError");
+    tfe("splice", [void 0, -1, []], "RangeError");
+    tfe("splice", [veggies, 7, []], "RangeError");
+    tfe("splice", [veggies, 6, []], "TypeError");
+    tf("splice", [void 0, 0, 0, []], [null]);
+    deepEquals(veggies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
+
+    var to_sort = [5, 3, 4, 1, 12];
+    yield ytf("sort", [NaN, "numeric"], null);
+    yield ytf("sort", [to_sort], [1, 12, 3, 4, 5]);
+    yield ytf("sort", [to_sort, action], [1, 12, 3, 4, 5]);
+    yield ytf("sort", [to_sort, "default"], [1, 12, 3, 4, 5]);
+    yield ytf("sort", [to_sort, "reverse"], [5, 4, 3, 12, 1]);
+    yield ytf("sort", [to_sort, "numeric"], [1, 3, 4, 5, 12]);
+    yield ytf("sort", [to_sort, "ciremun"], [12, 5, 4, 3, 1]);
+    yield ytf("sort", [to_sort, function(a, b){
+        return a < b ? -1 : (a === b ? 0 : 1);
+    }], [1, 3, 4, 5, 12]);
+    deepEquals(to_sort, [5, 3, 4, 1, 12], "should not be mutated");
+
+    tf("delete", [obj, ["foo", "bar", 10]], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {"bar": {}}//or "foo": {} ???
+    });
+    assertObjNotMutated();
+    tf("delete", [{"0": void 0}, "1"], {"0": null});
+
+    tf("encode", [{blah: 1}], "{\"blah\":1}");
+    tf("encode", [[1, 2]], "[1,2]");
+    tf("encode", [12], "12");
+    tf("encode", ["12"], "\"12\"");
+    //all nulls are treated the same
+    tf("encode", [null], "null");
+    tf("encode", [NaN], "null");
+    tf("encode", [void 0], "null");
+    //use .as("String") rules for other types
+    tf("encode", [action], "\"[Action]\"");
+    tf("encode", [/a/ig], "\"re#a#gi\"");
+    (function(){
+        tf("encode", [arguments], "{\"0\":\"a\",\"1\":\"b\"}");
+    }("a", "b"));
+    //testing it nested
+    tf("encode", [{fn: _.noop, n: NaN, u: void 0}], "{\"fn\":\"[Function]\",\"n\":null,\"u\":null}");
+
+    //testing indent options
+    tf("encode", [{a: 1, b: 2}, 0], "{\"a\":1,\"b\":2}");
+    tf("encode", [{a: 1, b: 2}, 4], "{\n    \"a\": 1,\n    \"b\": 2\n}");
+    tf("encode", [{a: 1, b: 2}, "2"], "{\n  \"a\": 1,\n  \"b\": 2\n}");
+    tf("encode", [{a: 1, b: 2}, null], "{\"a\":1,\"b\":2}", "default indent to 0");
+    tf("encode", [{a: 1, b: 2}, arguments], "{\"a\":1,\"b\":2}", "default indent to 0");
+    tf("encode", [{a: 1, b: 2}, _.noop], "{\"a\":1,\"b\":2}", "default indent to 0");
+
+    tf("keys", [obj], ["colors", "pi", "foo"]);
+    tf("keys", [obj, ["foo", "bar"]], ["10"]);
+    assertObjNotMutated();
+    tf("keys", [["not a map"]], []);
+
+    tf("values", [obj], [
+        "many",
+        [3, 1, 4, 1, 5, 9, 3],
+        {"bar": {"10": "I like cheese"}}
+    ]);
+    tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
+    assertObjNotMutated();
+    tf("values", [["not a map"]], []);
+
+    tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
+    tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
+    tf("put", [{key: 5}, ["baz"], {foo: "bar"}], {key: 5, baz: {foo: "bar"}});
+    tf("put", [{key: 5}, ["qux"], "wat?"], {key: 5, qux: "wat?"});
+    tf("put", [{key: 5}, [null], "wat?"], {key: 5, "null": "wat?"});
+    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
+    tf("put", [{key: 5}, [void 0], "wat?"], {key: 5, "null": "wat?"});
+    tf("put", [{key: 5}, [NaN], "wat?"], {key: 5, "null": "wat?"});
+    tf("put", [{key: 5}, [_.noop], "wat?"], {key: 5, "[Function]": "wat?"});
+
+    tf("put", [obj, ["foo"], {baz: "qux"}], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {"baz": "qux"},
+    }, "overwrite at the path, even if to_set and curr val are both maps");
+    tf("put", [obj, ["foo", "bar", 11], "wat?"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {
+                "10": "I like cheese",
+                "11": "wat?",
+            },
+        }
+    });
+    tf("put", [obj, ["foo", "bar", 10], "no cheese"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {"10": "no cheese"},
+        }
+    });
+    tf("put", [obj, {flop: 12}], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {"bar": {"10": "I like cheese"}},
+        "flop": 12
+    });
+    assertObjNotMutated();
+    tf("put", [{}, ["key1"], "value2"], {key1: "value2"});
+    tf("put", [{}, [], {key2: "value3"}], {key2: "value3"});
+    tf("put", [{key: 5}, "foo", {key2: "value3"}], {key: 5, "foo": {key2: "value3"}});
+    tf("put", [{key: 5}, "key", 7], {key: 7});
+    tf("put", [{key: 5}, ["key"], 9], {key: 9});
+
+    tf("put", [5, ["key"], 9], 5, "if val is not a Map or Array, return the val");
+    tf("put", ["wat", ["key"], 9], "wat", "if val is not a Map or Array, return the val");
+    tf("put", [null, ["key"], 9], null, "if val is not a Map or Array, return the val");
+    tf("put", [{a: NaN, b:void 0}], {a: null, b: null}, "if no arguments, return the val (with the correct nulls)");
+
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {}, ["0", "0"], "foo")),
+        "{\"0\":{\"0\":\"foo\"}}",
+        "don't use arrays by default, i.e. don't do {\"0\":[\"foo\"]}"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {}, [0, 1], "foo")),
+        "{\"0\":{\"1\":\"foo\"}}",
+        "don't do {\"0\":[null,\"foo\"]}"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, [], [0, 0], "foo")),
+        "[{\"0\":\"foo\"}]"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, [["wat?"]], [0, 0], "foo")),
+        "[[\"foo\"]]",
+        "if the nested value is an array, keep it an array"
+    );
+
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {}, ["a", "b"], [])),
+        "{\"a\":{\"b\":[]}}",
+        "preserve type of to_set"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, [], [0], ["foo"])),
+        "[[\"foo\"]]",
+        "preserve type of to_set"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, [], [], ["foo"])),
+        "[\"foo\"]",
+        "preserve type of to_set"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", [0])),
+        "{\"foo\":[0]}",
+        "preserve type of to_set"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {}, "foo", ["bar"])),
+        "{\"foo\":[\"bar\"]}",
+        "preserve type of to_set"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, [{foo: 1}, {bar: 2}], [1, "bar", "baz"], 4)),
+        "[{\"foo\":1},{\"bar\":{\"baz\":4}}]"
+    );
+
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", 1], 4)),
+        "{\"one\":[2,4]}",
+        "number index"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "1"], 4)),
+        "{\"one\":[2,4]}",
+        "Array index can be a string"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "2"], 4)),
+        "{\"one\":[2,3,4]}",
+        "Array index at the end"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "3"], 4)),
+        "{\"one\":{\"0\":2,\"1\":3,\"3\":4}}",
+        "convert Array to Map if sparse array is attempted"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo"], 4)),
+        "{\"one\":{\"0\":2,\"1\":3,\"foo\":4}}",
+        "convert Array to Map if non-index path is given"
+    );
+    t.equals(
+        JSON.stringify(stdlib["put"](defaultCTX, {one: [2, 3]}, ["one", "foo", "0"], 4)),
+        "{\"one\":{\"0\":2,\"1\":3,\"foo\":{\"0\":4}}}",
+        "convert Array to Map if non-index path is given"
+    );
+
+    tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
+    tf("get", [obj, "colors"], "many");
+    assertObjNotMutated();
+
+    tf("set", [obj, ["foo", "baz"], "qux"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {"10": "I like cheese"},
+            "baz": "qux"
+        }
+    });
+    tf("set", [obj, "flop", 12], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {"10": "I like cheese"}
+        },
+        "flop": 12
+    });
+    tf("set", [obj, "colors", ["R", "G", "B"]], {
+        "colors": ["R", "G", "B"],
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {"10": "I like cheese"}
+        }
+    });
+    tf("set", [obj, ["foo", "bar", "10"], "modified a sub object"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, 5, 9, 3],
+        "foo": {
+            "bar": {"10": "modified a sub object"}
+        }
+    });
+    assertObjNotMutated();
+
+    tf("intersection", [[[2], 2, 1, NaN], [[2], "1", 2, void 0]], [[2], 2, null]);
+    tf("intersection", [[[0], {}], [[1], []]], []);
+    tf("intersection", [[]], []);
+    tf("intersection", [[{}]], []);
+    tf("intersection", [{}, [{}]], [{}]);
+
+    tf("union", [[2], [1, 2]], [2, 1]);
+    tf("union", [[1, 2], [1, 4]], [1, 2, 4]);
+    tf("union", [[{"x":2}], [{"x":1}]], [{"x":2}, {"x":1}]);
+    tf("union", [[]], []);
+    tf("union", [[], {"x":1}], [{"x":1}]);
+    tf("union", [{"x":1}, []], [{"x":1}]);
+    tf("union", [{"x":1}], {"x":1});
+
+    tf("difference", [[2, 1], [2, 3]], [1]);
+    tf("difference", [[2, 1], 2], [1]);
+    tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
+    tf("difference", [{"x":NaN}, []], [{"x":null}]);
+    tf("difference", [{"x":NaN}], {"x":null});
+
+    tf("has", [[1, 2, 3, 4], [4, 2]], true);
+    tf("has", [[1, 2, 3, 4], [4, 5]], false);
+    tf("has", [[[null, [action]]], [[void 0, [action]]]], true);
+    tf("has", [[], []], true);
+    tf("has", [[]], true);
+
+    tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
+    tf("once", [{"a":void 0}], {"a":null});
+
+    tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
+    tf("duplicates", [{"0":1, "1":1}], []);
+
+    tf("unique", [[1, 2, 1, [3], [4], [4]]], [1, 2, [3], [4]]);
+    tf("unique", [{"0":1, "1":1}], {"0":1, "1":1});
 });
 
-//test("klog", function(t){
-//    t.plan(4);
-//    var val = 42;
-//    t.equals(stdlib.klog({
-//        emit: function(kind, obj){
-//            t.equals(kind, "klog");
-//            t.equals(obj.val, 42);
-//            t.equals(obj.message, "message 1");
-//        }
-//    }, val, "message 1"), val);
-//});
-//
-//test("defaultsTo - testing debug logging", function(t){
-//
-//    var messages = [];
-//
-//    var ctx = {
-//        emit: function(kind, message){
-//            t.equals(kind, "debug");
-//
-//            messages.push(message);
-//        }
-//    };
-//
-//    t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
-//    t.equals(stdlib.defaultsTo(ctx, null, NaN, "message 1"), null, "should emit debug");
-//    t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
-//    t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
-//    deepEqual(t, stdlib.defaultsTo(ctx, [void 0]), [null]);
-//    testFnErr(t, "defaultsTo", [null], "Error");
-//
-//    deepEquals(t, messages, [
-//        "[DEFAULTSTO] message 1",
-//        "[DEFAULTSTO] [Function]",//message should use KRL toString rules
-//    ]);
-//
-//    t.end();
-//});
+test("klog", function(t){
+    t.plan(4);
+    var val = 42;
+    t.equals(stdlib.klog({
+        emit: function(kind, obj){
+            t.equals(kind, "klog");
+            t.equals(obj.val, 42);
+            t.equals(obj.message, "message 1");
+        }
+    }, val, "message 1"), val);
+});
+
+test("defaultsTo - testing debug logging", function(t){
+
+    var messages = [];
+
+    var ctx = {
+        emit: function(kind, message){
+            t.equals(kind, "debug");
+
+            messages.push(message);
+        }
+    };
+
+    t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
+    t.equals(stdlib.defaultsTo(ctx, null, NaN, "message 1"), null, "should emit debug");
+    t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
+    t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
+    deepEqual(t, stdlib.defaultsTo(ctx, [void 0]), [null]);
+    testFnErr(t, "defaultsTo", [null], "Error");
+
+    deepEqual(t, messages, [
+        "[DEFAULTSTO] message 1",
+        "[DEFAULTSTO] [Function]",//message should use KRL toString rules
+    ]);
+
+    t.end();
+});

--- a/src/tests.js
+++ b/src/tests.js
@@ -933,9 +933,11 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
     tf("once", [{"a": void 0}], {"a": void 0});
+    tf("once", [[1, NaN, "a"]], [1, null, "a"]);
 
     tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
     tf("duplicates", [{"0":1, "1":1}], []);
+    tf("duplicates", [[1, 3, null, NaN, void 0, 3]], [3, null]);
 
     tf("unique", [[1, 2, 1, [3], [4], [4]]], [1, 2, [3], [4]]);
     tf("unique", [{"0":1, "1":1}], {"0":1, "1":1});

--- a/src/tests.js
+++ b/src/tests.js
@@ -569,7 +569,8 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("join", [a, ";"], "3;4;5");
     tf("join", [a], "3,4,5", "default to ,");
     t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    tf("join", [b], null);
+    tf("join", [b], "null");
+    tf("join", [NaN], "null");
     tf("join", [c, action], "");
     t.deepEquals(c, [], "should not be mutated");
     tf("join", [["<", ">"], /|/], "<re#|#>");

--- a/src/tests.js
+++ b/src/tests.js
@@ -672,7 +672,7 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("delete", [obj, ["foo", "bar", 10]], {
         "colors": "many",
         "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {"bar": {}}//or "foo": {} ???
+        "foo": {"bar": {}}
     });
     assertObjNotMutated();
     tf("delete", [{"0": void 0}, "1"], {"0": void 0});
@@ -704,8 +704,13 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("keys", [obj], ["colors", "pi", "foo"]);
     tf("keys", [obj, ["foo", "bar"]], ["10"]);
+    tf("keys", [obj, ["pi"]], ["0", "1", "2", "3", "4", "5", "6"]);
+    tf("keys", [obj, ["foo", "not"]], [], "bad path");
     assertObjNotMutated();
-    tf("keys", [["not a map"]], []);
+    tf("keys", [["wat", {da: "heck"}]], ["0", "1"]);
+    tf("keys", [null], [], "not a map or array");
+    tf("keys", [_.noop], [], "not a map or array");
+    tf("keys", [{a: "b"}, "not-found"], [], "bad path");
 
     tf("values", [obj], [
         "many",
@@ -713,8 +718,12 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
         {"bar": {"10": "I like cheese"}}
     ]);
     tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
+    tf("values", [obj, ["pi"]], [3, 1, 4, 1, 5, 9, 3]);
+    tf("values", [obj, ["foo", "not"]], []);
     assertObjNotMutated();
-    tf("values", [["not a map"]], []);
+    tf("values", [["an", "array"]], ["an", "array"]);
+    tf("values", [void 0], [], "not a map or array");
+    tf("values", [_.noop], [], "not a map or array");
 
     tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
     tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
@@ -849,7 +858,10 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
     tf("get", [obj, "colors"], "many");
+    tf("get", [obj, ["pi", 2]], 4);
     assertObjNotMutated();
+    tf("get", [["a", "b", {"c": ["d", "e"]}], [2, "c", 1]], "e", "get works on arrays and objects equally");
+    tf("get", [["a", "b", {"c": ["d", "e"]}], ["2", "c", "1"]], "e", "array indices can be strings");
 
     tf("set", [obj, ["foo", "baz"], "qux"], {
         "colors": "many",
@@ -881,7 +893,16 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
             "bar": {"10": "modified a sub object"}
         }
     });
+    tf("set", [obj, ["pi", 4, "a"], "wat?"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, {a: "wat?"}, 9, 3],
+        "foo": {"bar": {"10": "I like cheese"}}
+    });
     assertObjNotMutated();
+
+    tf("set", [["a", "b", "c"], [1], "wat?"], ["a", "wat?", "c"]);
+    tf("set", [["a", "b", "c"], ["1"], "wat?"], ["a", "wat?", "c"]);
+    tf("set", [[{a: [{b: 1}]}], [0, "a", 0, "b"], "wat?"], [{a: [{b: "wat?"}]}]);
 
     tf("intersection", [[[2], 2, 1, null], [[2], "1", 2, void 0]], [[2], 2, null]);
     tf("intersection", [[[0], {}], [[1], []]], []);

--- a/src/types.js
+++ b/src/types.js
@@ -29,12 +29,8 @@ types.isArray = function(val){
 types.isMap = function(val){
     //Can't use _.isPlainObject b/c it's to restrictive on what is a "plain" object
     //especially when accepting values from other libraries outside of KRL
-    return _.isObject(val)
+    return types.isArrayOrMap(val)
         && !_.isArray(val)
-        && !_.isFunction(val)
-        && !_.isRegExp(val)
-        && !_.isString(val)
-        && !_.isNumber(val)
     ;
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -147,4 +147,10 @@ types.encode = function(val, indent){
     }, indent);
 };
 
+types.isEqual = function(left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    return _.isEqual(left, right);
+};
+
 module.exports = types;


### PR DESCRIPTION
Fixes issues [289](https://github.com/Picolab/pico-engine/issues/289), [288](https://github.com/Picolab/pico-engine/issues/288), [224](https://github.com/Picolab/pico-engine/issues/224), [252](https://github.com/Picolab/pico-engine/issues/252), [222](https://github.com/Picolab/pico-engine/issues/222), [209](https://github.com/Picolab/pico-engine/issues/209), and [201](https://github.com/Picolab/pico-engine/issues/201).

Related: [weak typing/polymorphism](https://github.com/Picolab/pico-engine/issues/235), [better error reporting](https://github.com/Picolab/pico-engine/issues/67)

Not covered: [system errors](https://github.com/Picolab/pico-engine/issues/89), [exposed JS operators](https://github.com/Picolab/pico-engine/issues/277), [different ways to get map values](https://github.com/Picolab/pico-engine/issues/223)

Note (as commented) that `types.cleanNulls` deep clones arrays and maps as a side effect.

Sorry for the messy commits - I assume we'll squash merge?

~JavaScript's `sort` doesn't always compare map values, so `ltEqGt` is wrong IMO~ for language user simplicity I made comparisons between different or deep types false except for exact equality when relevant (no `null >= 0` problem)

~no code's recursion depth should depend on any map's depth/key path length~ I guess there's no point worrying about it as long as we inherit [Lodash's same problem](https://github.com/lodash/lodash/search?q=%22call+stack%22)