### PR TITLE
Type checking review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "krl-stdlib",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -64,13 +64,13 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -88,13 +88,13 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.0.3"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-union": {
@@ -131,14 +131,38 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -148,9 +172,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "brace-expansion": {
@@ -190,16 +214,34 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "chokidar": {
@@ -208,9 +250,8 @@
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -235,9 +276,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -247,9 +288,9 @@
       "dev": true
     },
     "co-callback": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.0.tgz",
-      "integrity": "sha1-7BtFewjvKCCrMW/8mQZFPgoCde4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/co-callback/-/co-callback-1.2.1.tgz",
+      "integrity": "sha512-frKVXlf1KFrlzojOrHIR4HPW6MPu78xb7eYp0xqvSY7ryoJjt5tlxf67ZQq8ABL0jIC7OsB4FShNTzRL0Sk/Vg==",
       "dev": true,
       "requires": {
         "co": "4.6.0"
@@ -283,7 +324,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
     },
@@ -294,13 +335,14 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "debug": {
@@ -331,7 +373,15 @@
       "dev": true,
       "requires": {
         "foreach": "2.0.5",
-        "object-keys": "0.4.0"
+        "object-keys": "1.0.11"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
+        }
       }
     },
     "defined": {
@@ -352,7 +402,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "doctrine": {
@@ -372,13 +422,13 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
+      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
@@ -402,16 +452,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
-      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
+      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.1.0",
         "concat-stream": "1.6.0",
-        "cross-spawn": "4.0.2",
+        "cross-spawn": "5.1.0",
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
@@ -423,11 +473,11 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.1",
+        "inquirer": "3.2.3",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -440,6 +490,7 @@
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -461,7 +512,7 @@
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -526,7 +577,7 @@
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
         "tmp": "0.0.31"
       }
@@ -675,909 +726,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -1651,7 +803,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1670,15 +822,15 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1704,15 +856,15 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
+      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "external-editor": "2.0.4",
         "figures": "2.0.0",
         "lodash": "4.17.4",
@@ -1723,52 +875,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "is-binary-path": {
@@ -1777,7 +883,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -1949,9 +1055,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -2037,7 +1143,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-fn": {
@@ -2082,13 +1188,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-      "dev": true,
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2101,7 +1200,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "object-assign": {
@@ -2154,6 +1253,16 @@
         "tree-kill": "1.1.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2320,9 +1429,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -2342,24 +1451,23 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -2419,9 +1527,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2469,6 +1577,21 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -2510,23 +1633,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "string.prototype.trim": {
@@ -2536,17 +1642,25 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.0",
-        "function-bind": "1.1.0"
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {
@@ -2583,6 +1697,28 @@
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -2629,10 +1765,10 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
         "for-each": "0.3.2",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "glob": "7.1.2",
         "has": "1.0.1",
         "inherits": "2.0.3",
@@ -2644,6 +1780,18 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2697,15 +1845,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
         }
       }
     },
@@ -2752,9 +1891,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -2779,6 +1918,15 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dev": true,
+      "requires": {
+        "object-keys": "0.4.0"
       }
     },
     "yallist": {

--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,9 @@ stdlib.extract = function(ctx, val, regex){
         return [];
     }
     val = types.toString(val);
-    regex = types.cleanNulls(regex);
+    if(!types.isRegExp(regex)){
+        regex = new RegExp(types.toString(regex));
+    }
     var r = val.match(regex);
     if(!r){
         return [];

--- a/src/index.js
+++ b/src/index.js
@@ -504,6 +504,7 @@ stdlib.join = function(ctx, val, str){
     if(!types.isArray(val)){
         return val;
     }
+    val = types.cleanNulls(val);
     if(arguments.length < 3){
         return _.join(val, ",");
     }
@@ -862,6 +863,7 @@ stdlib.once = function(ctx, val){
         return val;
     }
     //TODO optimize
+    val = types.cleanNulls(val);
     var r = [];
     _.each(_.groupBy(val), function(group){
         if(group.length === 1){
@@ -875,6 +877,7 @@ stdlib.duplicates = function(ctx, val){
         return [];
     }
     //TODO optimize
+    val = types.cleanNulls(val);
     var r = [];
     _.each(_.groupBy(val), function(group){
         if(group.length > 1){

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ var iterBase = function*(val, iter){
 
 // some guidelines/suggestions:
 // 0. effectively check arguments.length when not fixed by the grammar (and consider null versus omitted)
-// 1. convert NaN's/void 0's to nulls (if cleanNulls could possibly have an effect) for all return values and other relevant values
+// 1. convert NaN's/void 0's when needed (i.e. use cleanNulls)
 // 2. don't mutate deep (array/map) arguments (cleanNulls doesn't, assignment can't)
 // 3. where strings/numbers/arrays are expected, convert to them when reasonable (don't coerce arrays to maps)
 // 4. prioritize errors on val's type (if applicable), then argument values/types/0. from left to right
@@ -83,7 +83,7 @@ stdlib["!="] = function(ctx, left, right){
 
 stdlib["+"] = function(ctx, left, right){
     if(arguments.length < 3){
-        return types.cleanNulls(left);
+        return left;
     }
     //if we have two "numbers" then do plus
     if(types.isNumber(left) && types.isNumber(right)){
@@ -98,7 +98,7 @@ stdlib["-"] = function(ctx, left, right){
         if(leftNumber === null){
             throw new TypeError("Cannot negate " + types.toString(left));
         }
-        return -types.cleanNulls(leftNumber);
+        return -leftNumber;
     }
     var rightNumber = types.numericCast(right);
     if(leftNumber === null || rightNumber === null){
@@ -184,7 +184,7 @@ stdlib.beesting = function(ctx, val){
 //
 stdlib.as = function(ctx, val, type){
     if(arguments.length < 3){
-        return types.cleanNulls(val);
+        return val;
     }
     var val_type = types.typeOf(val);
     if(val_type === type){
@@ -228,11 +228,10 @@ stdlib.isnull = function(ctx, val){
 };
 
 stdlib.klog = function(ctx, val, message){
-    val = types.cleanNulls(val);
     if(arguments.length < 3){
         ctx.emit("klog", {val: val});
     }else{
-        ctx.emit("klog", {val: val, message: types.cleanNulls(message)});
+        ctx.emit("klog", {val: val, message: types.toString(message)});
     }
     return val;
 };
@@ -243,7 +242,7 @@ stdlib["typeof"] = function(ctx, val){
 
 var format = function(val, template, specifier){
     return _.join(
-        _.map(types.toString(template).split(/\\\\/g), function(v){
+        _.map(template.split(/\\\\/g), function(v){
             return v.replace(new RegExp("(^|[^\\\\])" + specifier, "g"), "$1" + val + "");
         }),
         "\\"
@@ -254,7 +253,7 @@ stdlib.sprintf = function(ctx, val, template){
     if(arguments.length < 3){
         return "";
     }
-    template = types.cleanNulls(template);
+    template = types.toString(template);
     if(types.isNumber(val)){
         return format(val, template, "%d");
     }
@@ -266,12 +265,14 @@ stdlib.sprintf = function(ctx, val, template){
 
 stdlib.defaultsTo = function(ctx, val, defaultVal, message){
     if(!types.isNull(val)){
-        return types.cleanNulls(val); // not important whether defaultVal is missing
+        return val; // not important whether defaultVal is missing
     }
     if(arguments.length < 3){
         throw new Error("The .defaultsTo() operator needs a default value");
     }
-    if(!types.isNull(message)) ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
+    if(!types.isNull(message)){
+        ctx.emit("debug", "[DEFAULTSTO] " + types.toString(message));
+    }
     return types.cleanNulls(defaultVal);
 };
 
@@ -305,7 +306,7 @@ stdlib.capitalize = function(ctx, val){
 };
 stdlib.decode = function(ctx, val){
     if(!types.isString(val)){
-        return types.cleanNulls(val);
+        return val;
     }
     try{
         return JSON.parse(val);
@@ -347,7 +348,7 @@ stdlib.ord = function(ctx, val){
 };
 stdlib.replace = function(ctx, val, regex, replacement){
     if(arguments.length < 3){
-        return types.cleanNulls(val);
+        return val;
     }
     val = types.toString(val);
     if(!types.isString(regex) && !types.isRegExp(regex)){
@@ -360,13 +361,15 @@ stdlib.replace = function(ctx, val, regex, replacement){
 };
 stdlib.split = function(ctx, val, split_on){
     val = types.toString(val);
-    split_on = types.cleanNulls(split_on); // toString?
+    if( ! types.isRegExp(split_on)){
+        split_on = types.toString(split_on);
+    }
     return val.split(split_on);
 };
 stdlib.substr = function(ctx, val, start, len){
     start = types.numericCast(start);
     if(start === null){
-        return types.cleanNulls(val);
+        return val;
     }
     val = types.toString(val);
     if(start > val.length){
@@ -391,7 +394,6 @@ stdlib.uc = function(ctx, val){
 //Collection operators//////////////////////////////////////////////////////////
 //operators using KRL functions are generators to be async-friendly (co library)
 stdlib.all = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         val = [val];
     }
@@ -416,7 +418,6 @@ stdlib.any = function*(ctx, val, iter){
     if(!types.isFunction(iter)){
         return false;
     }
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         val = [val];
     }
@@ -435,14 +436,13 @@ stdlib.none = function*(ctx, val, iter){
     return !(yield stdlib.any(ctx, val, iter));
 };
 stdlib.append = function(ctx, val, others){
-    return _.concat.apply(void 0, types.cleanNulls(_.tail(_.toArray(arguments))));
+    return _.concat.apply(void 0, _.tail(_.toArray(arguments)));
 };
 // works for arrays (documented) and maps (undocumented)
 stdlib.collect = function*(ctx, val, iter){
     if(!types.isFunction(iter)){
         return {};
     }
-    val = types.cleanNulls(val);
     if(!types.isArrayOrMap(val)){
         val = [val];
     }
@@ -458,7 +458,6 @@ stdlib.collect = function*(ctx, val, iter){
     return grouped;
 };
 stdlib.filter = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isFunction(iter)){
         return val;
     }
@@ -482,15 +481,15 @@ stdlib.filter = function*(ctx, val, iter){
 };
 stdlib.head = function(ctx, val){
     if(!types.isArray(val)){
-        return types.cleanNulls(val); // head is for arrays; pretend val is a one-value array
+        return val; // head is for arrays; pretend val is a one-value array
     }
-    return types.cleanNulls(val[0]);
+    return val[0];
 };
 stdlib.tail = function(ctx, val){
     if(!types.isArray(val)){
         return [];
     }
-    return types.cleanNulls(_.tail(val));
+    return _.tail(val);
 };
 stdlib.index = function(ctx, val, elm){
     if(arguments.length < 3){
@@ -504,7 +503,6 @@ stdlib.index = function(ctx, val, elm){
     return _.findIndex(val, _.partial(_.isEqual, elm));
 };
 stdlib.join = function(ctx, val, str){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
@@ -521,7 +519,6 @@ stdlib.length = function(ctx, val){
     return 0; // we could check function.prototype.length
 };
 stdlib.map = function*(ctx, val, iter){
-    val = types.cleanNulls(val);
     if(!types.isFunction(iter)){
         return val;
     }
@@ -570,7 +567,7 @@ stdlib.pairwise = function*(ctx, val, iter){
     for(i = 0; i < max_len; i++){
         args2 = [];
         for(j = 0; j < val.length; j++){
-            args2.push(types.cleanNulls(val[j][i]));
+            args2.push(val[j][i]);
         }
         r.push(yield iter(ctx, args2));
     }
@@ -582,20 +579,19 @@ stdlib.reduce = function*(ctx, val, iter, dflt){
     }
     var no_default = arguments.length < 4;
     if(val.length === 0){
-        return no_default ? 0 : types.cleanNulls(dflt);
+        return no_default ? 0 : dflt;
     }
     if(!types.isFunction(iter) && (no_default || val.length > 1)){
         throw new Error("The .reduce() operator cannot use " + types.toString(iter) + " as a function");
     }
     if(val.length === 1){
-        var head = types.cleanNulls(val[0]);
+        var head = val[0];
         if(no_default){
             return head;
         }
-        return iter(ctx, [types.cleanNulls(dflt), head]);
+        return iter(ctx, [dflt, head]);
     }
-    val = types.cleanNulls(val);
-    var acc = types.cleanNulls(dflt);
+    var acc = dflt;
     var is_first = true;
     yield iterBase(val, function*(v, k, obj){
         if(is_first && no_default){
@@ -609,11 +605,10 @@ stdlib.reduce = function*(ctx, val, iter, dflt){
     return acc;
 };
 stdlib.reverse = function(ctx, val){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
-    return _.reverse(val);
+    return _.reverse(_.cloneDeep(val));
 };
 stdlib.slice = function(ctx, val, start, end){
     if(!types.isArray(val)){
@@ -623,7 +618,7 @@ stdlib.slice = function(ctx, val, start, end){
         return null;
     }
     if(arguments.length === 2){
-        return types.cleanNulls(val);
+        return val;
     }
     var firstIndex = types.numericCast(start);
     if(firstIndex === null){
@@ -634,7 +629,7 @@ stdlib.slice = function(ctx, val, start, end){
             ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from 0 to " + firstIndex));
             return null;
         }
-        return types.cleanNulls(_.slice(val, 0, firstIndex + 1));
+        return _.slice(val, 0, firstIndex + 1);
     }
     var secondIndex = types.numericCast(end);
     if(secondIndex === null){
@@ -646,7 +641,7 @@ stdlib.slice = function(ctx, val, start, end){
         secondIndex = temp;
     }
     if(firstIndex >= 0 && secondIndex < val.length){
-        return types.cleanNulls(_.slice(val, firstIndex, secondIndex + 1));
+        return _.slice(val, firstIndex, secondIndex + 1);
     }
     ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from " + firstIndex + " to " + secondIndex));
     return null;
@@ -677,12 +672,12 @@ stdlib.splice = function(ctx, val, start, n_elms, value){
     if(n_elms_number < 0 || startIndex + n_elms_number > val.length){
         n_elms_number = val.length - startIndex;
     }
-    var part1 = types.cleanNulls(_.slice(val, 0, startIndex));
-    var part2 = types.cleanNulls(_.slice(val, startIndex + n_elms));
+    var part1 = _.slice(val, 0, startIndex);
+    var part2 = _.slice(val, startIndex + n_elms);
     if(arguments.length < 5){
         return _.concat(part1, part2);
     }
-    return _.concat(part1, types.cleanNulls(value), part2);
+    return _.concat(part1, value, part2);
 };
 stdlib.sort = (function(){
     var swap = function(arr, i, j){
@@ -691,7 +686,7 @@ stdlib.sort = (function(){
         arr[j] = temp;
     };
     return function*(ctx, val, sort_by){
-        val = types.cleanNulls(val);
+        val = _.cloneDeep(val);
         if(!types.isArray(val)){
             return val;
         }
@@ -718,6 +713,7 @@ stdlib.sort = (function(){
         var sorted = val;
         var i, j, a, b;
         var len = sorted.length;
+        //TODO optimize with a better sort algorithm
         for (i = len - 1; i >= 0; i--){
             for(j = 1; j <= i; j++){
                 a = sorted[j-1];
@@ -733,7 +729,7 @@ stdlib.sort = (function(){
 stdlib["delete"] = function(ctx, val, path){
     path = toKeyPath(path);
     //TODO optimize
-    var n_val = types.cleanNulls(val);
+    var n_val = _.cloneDeep(val);
     _.unset(n_val, path);
     return n_val;
 };
@@ -747,7 +743,6 @@ var isSafeArrayIndex = function(arr, key){
 };
 
 stdlib.put = function(ctx, val, path, to_set){
-    val = types.cleanNulls(val);
     if(!types.isArrayOrMap(val) || arguments.length < 3){
         return val;
     }
@@ -755,6 +750,7 @@ stdlib.put = function(ctx, val, path, to_set){
         to_set = path;
         path = [];
     }
+    val = _.cloneDeep(val);
     path = toKeyPath(path);
     if(_.isEmpty(path)){
         if(types.isMap(to_set)){
@@ -803,7 +799,6 @@ stdlib.keys = function(ctx, val, path){
         return [];
     }
     if(path){
-        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.keys(_.get(val, path));
     }
@@ -814,11 +809,10 @@ stdlib.values = function(ctx, val, path){
         return [];
     }
     if(path){
-        val = types.cleanNulls(val);
         path = toKeyPath(path);
         return _.values(_.get(val, path));
     }
-    return types.cleanNulls(_.values(val));
+    return _.values(val);
 };
 stdlib.intersection = function(ctx, a, b){
     if(arguments.length < 3){
@@ -872,7 +866,6 @@ stdlib.has = function(ctx, val, other){
     return stdlib.difference(ctx, other, val).length === 0;
 };
 stdlib.once = function(ctx, val){
-    val = types.cleanNulls(val);
     if(!types.isArray(val)){
         return val;
     }
@@ -891,7 +884,6 @@ stdlib.duplicates = function(ctx, val){
     }
     //TODO optimize
     var r = [];
-    val = types.cleanNulls(val);
     _.each(_.groupBy(val), function(group){
         if(group.length > 1){
             r.push(group[0]);
@@ -912,7 +904,6 @@ stdlib["get"] = function(ctx, obj, path){
     if(!types.isMap(obj)){
         return null;
     }
-    obj = types.cleanNulls(obj);
     path = toKeyPath(path);
     return _.get(obj, path, null);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -793,7 +793,7 @@ stdlib.encode = function(ctx, val, indent){
     return types.encode(val, indent);
 };
 stdlib.keys = function(ctx, val, path){
-    if(!types.isMap(val)){
+    if(!types.isArrayOrMap(val)){
         return [];
     }
     if(path){
@@ -803,7 +803,7 @@ stdlib.keys = function(ctx, val, path){
     return _.keys(val);
 };
 stdlib.values = function(ctx, val, path){
-    if(!types.isMap(val)){
+    if(!types.isArrayOrMap(val)){
         return [];
     }
     if(path){
@@ -892,7 +892,7 @@ stdlib.unique = function(ctx, val){
 };
 
 stdlib["get"] = function(ctx, obj, path){
-    if(!types.isMap(obj)){
+    if(!types.isArrayOrMap(obj)){
         return null;
     }
     path = toKeyPath(path);
@@ -900,7 +900,7 @@ stdlib["get"] = function(ctx, obj, path){
 };
 
 stdlib["set"] = function(ctx, obj, path, val){
-    if(!types.isMap(obj)){
+    if(!types.isArrayOrMap(obj)){
         return obj;
     }
     path = toKeyPath(path);

--- a/src/index.js
+++ b/src/index.js
@@ -502,9 +502,9 @@ stdlib.index = function(ctx, val, elm){
 };
 stdlib.join = function(ctx, val, str){
     if(!types.isArray(val)){
-        return val;
+        return types.toString(val);
     }
-    val = types.cleanNulls(val);
+    val = _.map(val, types.toString);
     if(arguments.length < 3){
         return _.join(val, ",");
     }

--- a/src/tests.js
+++ b/src/tests.js
@@ -391,6 +391,9 @@ test("string operators", function(t){
     tf("extract", ["This is a string", /(boot)/], []);
     tf("extract", ["I like cheese", /like (\w+)/], ["cheese"]);
     tf("extract", ["I like cheese", /(e)/g], ["e", "e", "e", "e"]);
+    tf("extract", ["I like cheese", "(ch.*)"], ["cheese"], "convert strings to RegExp");
+    tf("extract", ["what the null?", /null/], []);
+    tf("extract", ["what the null?", void 0], []);
 
     tf("lc", ["UppER"], "upper");
 

--- a/src/tests.js
+++ b/src/tests.js
@@ -897,8 +897,8 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("difference", [[2, 1], [2, 3]], [1]);
     tf("difference", [[2, 1], 2], [1]);
     tf("difference", [[{"x":2}, {"x":1}], [{"x":2}, {"x":3}]], [{"x":1}]);
-    tf("difference", [{"x":NaN}, []], [{"x":null}]);
-    tf("difference", [{"x":NaN}], {"x":null});
+    tf("difference", [{"x":null}, []], [{"x":null}]);
+    tf("difference", [{"x":null}], {"x":null});
 
     tf("has", [[1, 2, 3, 4], [4, 2]], true);
     tf("has", [[1, 2, 3, 4], [4, 5]], false);
@@ -941,7 +941,7 @@ test("defaultsTo - testing debug logging", function(t){
     };
 
     t.equals(stdlib.defaultsTo(ctx, null, 42), 42, "no message to log");
-    t.equals(stdlib.defaultsTo(ctx, null, NaN, "message 1"), null, "should emit debug");
+    t.ok(_.isNaN(stdlib.defaultsTo(ctx, null, NaN, "message 1")), "should emit debug");
     t.equals(stdlib.defaultsTo(ctx, null, 42, _.noop), 42, "message should use KRL toString rules");
     t.equals(stdlib.defaultsTo(ctx, null, 42, NaN), 42, "no message to log");
     t.deepEqual(stdlib.defaultsTo(ctx, [void 0]), [void 0]);

--- a/src/tests.js
+++ b/src/tests.js
@@ -933,9 +933,11 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("once", [[1, 2, 1, 3, 4, 4]], [2, 3]);
     tf("once", [{"a": void 0}], {"a": void 0});
+    tf("once", [[1, NaN, "a"]], [1, null, "a"]);
 
     tf("duplicates", [[1, 2, 1, 3, 4, 4]], [1, 4]);
     tf("duplicates", [{"0":1, "1":1}], []);
+    tf("duplicates", [[1, 3, null, NaN, void 0, 3]], [3, null]);
 
     tf("unique", [[1, 2, 1, [3], [4], [4]]], [1, 2, [3], [4]]);
     tf("unique", [{"0":1, "1":1}], {"0":1, "1":1});

--- a/src/tests.js
+++ b/src/tests.js
@@ -569,7 +569,8 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("join", [a, ";"], "3;4;5");
     tf("join", [a], "3,4,5", "default to ,");
     t.deepEquals(a, [3, 4, 5], "should not be mutated");
-    tf("join", [b], null);
+    tf("join", [b], "null");
+    tf("join", [NaN], "null");
     tf("join", [c, action], "");
     t.deepEquals(c, [], "should not be mutated");
     tf("join", [["<", ">"], /|/], "<re#|#>");

--- a/src/tests.js
+++ b/src/tests.js
@@ -672,7 +672,7 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
     tf("delete", [obj, ["foo", "bar", 10]], {
         "colors": "many",
         "pi": [3, 1, 4, 1, 5, 9, 3],
-        "foo": {"bar": {}}//or "foo": {} ???
+        "foo": {"bar": {}}
     });
     assertObjNotMutated();
     tf("delete", [{"0": void 0}, "1"], {"0": void 0});
@@ -704,8 +704,13 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("keys", [obj], ["colors", "pi", "foo"]);
     tf("keys", [obj, ["foo", "bar"]], ["10"]);
+    tf("keys", [obj, ["pi"]], ["0", "1", "2", "3", "4", "5", "6"]);
+    tf("keys", [obj, ["foo", "not"]], [], "bad path");
     assertObjNotMutated();
-    tf("keys", [["not a map"]], []);
+    tf("keys", [["wat", {da: "heck"}]], ["0", "1"]);
+    tf("keys", [null], [], "not a map or array");
+    tf("keys", [_.noop], [], "not a map or array");
+    tf("keys", [{a: "b"}, "not-found"], [], "bad path");
 
     tf("values", [obj], [
         "many",
@@ -713,8 +718,12 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
         {"bar": {"10": "I like cheese"}}
     ]);
     tf("values", [obj, ["foo", "bar"]], ["I like cheese"]);
+    tf("values", [obj, ["pi"]], [3, 1, 4, 1, 5, 9, 3]);
+    tf("values", [obj, ["foo", "not"]], []);
     assertObjNotMutated();
-    tf("values", [["not a map"]], []);
+    tf("values", [["an", "array"]], ["an", "array"]);
+    tf("values", [void 0], [], "not a map or array");
+    tf("values", [_.noop], [], "not a map or array");
 
     tf("put", [{key: 5}, {foo: "bar"}], {key: 5, foo: "bar"});
     tf("put", [{key: 5}, [], {foo: "bar"}], {key: 5, foo: "bar"});
@@ -849,7 +858,10 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
 
     tf("get", [obj, ["foo", "bar", "10"]], "I like cheese");
     tf("get", [obj, "colors"], "many");
+    tf("get", [obj, ["pi", 2]], 4);
     assertObjNotMutated();
+    tf("get", [["a", "b", {"c": ["d", "e"]}], [2, "c", 1]], "e", "get works on arrays and objects equally");
+    tf("get", [["a", "b", {"c": ["d", "e"]}], ["2", "c", "1"]], "e", "array indices can be strings");
 
     tf("set", [obj, ["foo", "baz"], "qux"], {
         "colors": "many",
@@ -881,7 +893,16 @@ ytest("collection operators", function*(t, ytfm, ytfe, ytf, tfe, tf){
             "bar": {"10": "modified a sub object"}
         }
     });
+    tf("set", [obj, ["pi", 4, "a"], "wat?"], {
+        "colors": "many",
+        "pi": [3, 1, 4, 1, {a: "wat?"}, 9, 3],
+        "foo": {"bar": {"10": "I like cheese"}}
+    });
     assertObjNotMutated();
+
+    tf("set", [["a", "b", "c"], [1], "wat?"], ["a", "wat?", "c"]);
+    tf("set", [["a", "b", "c"], ["1"], "wat?"], ["a", "wat?", "c"]);
+    tf("set", [[{a: [{b: 1}]}], [0, "a", 0, "b"], "wat?"], [{a: [{b: "wat?"}]}]);
 
     tf("intersection", [[[2], 2, 1, null], [[2], "1", 2, void 0]], [[2], 2, null]);
     tf("intersection", [[[0], {}], [[1], []]], []);

--- a/src/types.js
+++ b/src/types.js
@@ -29,12 +29,8 @@ types.isArray = function(val){
 types.isMap = function(val){
     //Can't use _.isPlainObject b/c it's to restrictive on what is a "plain" object
     //especially when accepting values from other libraries outside of KRL
-    return _.isObject(val)
+    return types.isArrayOrMap(val)
         && !_.isArray(val)
-        && !_.isFunction(val)
-        && !_.isRegExp(val)
-        && !_.isString(val)
-        && !_.isNumber(val)
     ;
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -147,4 +147,10 @@ types.encode = function(val, indent){
     }, indent);
 };
 
+types.isEqual = function(left, right){
+    left = types.cleanNulls(left);
+    right = types.cleanNulls(right);
+    return _.isEqual(left, right);
+};
+
 module.exports = types;


### PR DESCRIPTION
Overall this looks great! Those detailed error messages will really improve the UX of working with KRL. Thanks getting all those details.

I think checking null values should only be used at the point it becomes relevant. Equality, printing output (toString and json encode) and isNull. That’s it. Everywhere else it doesn’t matter.

So running cleanNulls before returning a value doesn’t matter b/c in JS land we expect to deal with null, undefined, and NaN. As such all KRL stdlib functions check for null only when they need to, so cleaning them before returning doesn’t actually help anything. Especially when you might return a cleaned null structure, then JS code mucks around and introduces a NaN, then passes it back into KRL code. Also by using cleanNull’s so much you will end up deep cloning way more than needed.

So I added types.isEqual so whenever equality checked so we can do it the KRL way (i.e. checking null values)

Yes we will need to increment the version, but I usually wait until the last possible second so we are sure it markes the point at which we published. I also use the `npm-release` cli to do it. Because it increments the version, tags the commit, and publishes in one command.